### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/RNDateTimePicker.podspec
+++ b/RNDateTimePicker.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/*.{h,m}"
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
 end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary


Xcode 12 won't build if a module depends on React instead of React-Core. 

Reference: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

## Test Plan

Use this branch to install with an app running on Xcode 12.


## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
