### PR TITLE
Resolve Missing Deploy Target in Windows

### DIFF
--- a/windows/DateTimePickerWindows/DateTimePickerWindows.vcxproj
+++ b/windows/DateTimePickerWindows/DateTimePickerWindows.vcxproj
@@ -167,6 +167,7 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
+	<Target Name="Deploy"/>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/windows/DateTimePickerWindows/DateTimePickerWindows.vcxproj
+++ b/windows/DateTimePickerWindows/DateTimePickerWindows.vcxproj
@@ -167,7 +167,7 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
-	<Target Name="Deploy"/>
+  <Target Name="Deploy"/>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>


### PR DESCRIPTION
# Summary

Fix error produced when module is added to a React Native app and run in Windows emulator.
Error reads: "The target "Deploy" does not exist in the project".

## Test Plan

Create a React Native Windows app.
Add datetimepicker module to app via `yarn add`.
Run `npx react-native run-windows`.
If app deploys successfully and loads in the Windows emulator, the code change has succeeded. 

### What's required for testing (prerequisites)?

A React Native Windows app. See [here](https://microsoft.github.io/react-native-windows/docs/getting-started) for setup instructions. 

### What are the steps to reproduce (after prerequisites)?

To reproduce error, run steps under "Test Plan" with old version of the module. 

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅  |
| Android |    ✅  |
| Windows |    ✅  |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
