### PR TITLE
Fix ios countdown

### DIFF
--- a/ios/RNDateTimePicker.m
+++ b/ios/RNDateTimePicker.m
@@ -34,15 +34,17 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (void)willMoveToSuperview:(UIView *)newSuperview
 {
   [super willMoveToSuperview:newSuperview];
-  NSDate *dateCopy = [[NSDate alloc] initWithTimeInterval:0 sinceDate:self.date];
-  [self setDate:[NSDate dateWithTimeIntervalSince1970:0]];
-  [self setDate:dateCopy animated:YES];
+  [self resetDate];
 }
 
 - (void)didChange
 {
   if (_onChange) {
     _onChange(@{ @"timestamp": @(self.date.timeIntervalSince1970 * 1000.0) });
+  }
+
+  if ([self datePickerMode] == UIDatePickerModeCountDownTimer) {
+    [self resetDate];
   }
 }
 
@@ -64,6 +66,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     if (![self.date isEqualToDate:date]) {
         [super setDate:date];
     }
+}
+
+- (void)resetDate
+{
+  NSDate *dateCopy = [[NSDate alloc] initWithTimeInterval:0 sinceDate:self.date];
+  [self setDate:[NSDate dateWithTimeIntervalSince1970:0]];
+  [self setDate:dateCopy animated:YES];
 }
 
 @end

--- a/ios/RNDateTimePicker.m
+++ b/ios/RNDateTimePicker.m
@@ -31,6 +31,14 @@
 
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
+- (void)willMoveToSuperview:(UIView *)newSuperview
+{
+  [super willMoveToSuperview:newSuperview];
+  NSDate *dateCopy = [[NSDate alloc] initWithTimeInterval:0 sinceDate:self.date];
+  [self setDate:[NSDate dateWithTimeIntervalSince1970:0]];
+  [self setDate:dateCopy animated:YES];
+}
+
 - (void)didChange
 {
   if (_onChange) {


### PR DESCRIPTION
# Summary

Fixes #30 

The fix requires calling the `setDate` twice:
 - the first time with a date that is different than what it will end up at
 - the second time with the animated flag enabled and a copy of the final date

I've tried with only a single call or different not generating a copy of the date, but was only able to resolve it with this combination. These steps are wrapped in the method `resetDate` which gets called from `willMoveToSuperview` (the view may be displayed, so we're going to perform this resetDate here) and after the `onChange` handler is called and if we're using the countdown mode.


## Test Plan

### What's required for testing (prerequisites)?
A DateTimePicker component with `'countdown'` mode running on an ios device or simulator:
```
<DateTimePicker
    mode={'countdown' as any}
    onChange={(event, date) => console.log('Updated!')}
    value={new Date(0, 0, 0, hours, minutes, seconds)}
/>
```

### What are the steps to reproduce (after prerequisites)?

#### Bug 1
  - Add logging to `onChange` handler to produce visible output
  - Load up component in App
  - Select the first value (notice onChange hasn't been triggered)
  - Select another value (onChange will be triggered)

#### Bug 2
  - Continuing from above
  - Select 0 Hours, 0 Minutes (slider will automatically change to 1 minute and onChange handler should be triggered)
  - Select another value other than 0 (notice onChange handler doesn't get triggered)
  - Select a third value other than 0 (onChange will be triggered once again)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |

This is an ios only bug. It shouldn't affect the existing android implementation.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
