### PR TITLE
Dismiss android pickers on react component unmount 

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
@@ -84,6 +84,25 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
     }
   }
 
+  @ReactMethod
+  public void close(Promise promise) {
+    FragmentActivity activity = (FragmentActivity) getCurrentActivity();
+    if (activity == null) {
+      promise.reject(
+              RNConstants.ERROR_NO_ACTIVITY,
+              "Tried to close a DatePicker dialog while not attached to an Activity");
+      return;
+    }
+
+    FragmentManager fragmentManager = activity.getSupportFragmentManager();
+    final RNDatePickerDialogFragment oldFragment = (RNDatePickerDialogFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);
+
+    if (oldFragment != null) {
+      oldFragment.dismiss();
+    }
+
+    promise.resolve(null);
+  }
   /**
    * Show a date picker dialog.
    *

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
@@ -84,6 +84,26 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void close(Promise promise) {
+    FragmentActivity activity = (FragmentActivity) getCurrentActivity();
+    if (activity == null) {
+      promise.reject(
+              RNConstants.ERROR_NO_ACTIVITY,
+              "Tried to close a TimePicker dialog while not attached to an Activity");
+      return;
+    }
+
+    FragmentManager fragmentManager = activity.getSupportFragmentManager();
+    final RNTimePickerDialogFragment oldFragment = (RNTimePickerDialogFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);
+
+    if (oldFragment != null) {
+      oldFragment.dismiss();
+    }
+
+    promise.resolve(null);
+  }
+
+  @ReactMethod
   public void open(@Nullable final ReadableMap options, Promise promise) {
 
     FragmentActivity activity = (FragmentActivity) getCurrentActivity();

--- a/src/datepicker.android.js
+++ b/src/datepicker.android.js
@@ -42,6 +42,10 @@ export default class DatePickerAndroid {
     return NativeModules.RNDatePickerAndroid.open(options);
   }
 
+  static async close(): Promise<null> {
+    return NativeModules.RNDatePickerAndroid.close();
+  }
+
   /**
    * A date has been selected.
    */

--- a/src/datetimepicker.android.js
+++ b/src/datetimepicker.android.js
@@ -15,6 +15,7 @@ import {
 } from './constants';
 import pickers from './picker';
 import invariant from 'invariant';
+import {useEffect} from 'react';
 
 import type {AndroidEvent, AndroidNativeProps} from './types';
 
@@ -65,6 +66,12 @@ export default function RNDateTimePicker(props: AndroidNativeProps) {
       });
       break;
   }
+
+  useEffect(() => {
+    // This effect runs on unmount, and will ensure the picker is closed.
+    // This allows for controlling the opening state of the picker through declarative logic in jsx.
+    return () => (pickers[mode] ?? pickers[MODE_DATE]).close();
+  }, [mode]);
 
   picker.then(
     function resolve({action, day, month, year, minute, hour}) {

--- a/src/timepicker.android.js
+++ b/src/timepicker.android.js
@@ -40,6 +40,10 @@ export default class TimePickerAndroid {
     return NativeModules.RNTimePickerAndroid.open(options);
   }
 
+  static async close(): Promise<null> {
+    return NativeModules.RNDatePickerAndroid.close();
+  }
+
   /**
    * A time has been selected.
    */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This commit makes the behavior of the android datetimepickers more in
line with other controlled components in react, where unmounting the
component actually dismisses the ui widget as well.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅ ❌     |
| Android |    ✅ ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
