### PR TITLE
Rerender of android picker no longer clears users selection 

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDate.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDate.java
@@ -1,26 +1,58 @@
 package com.reactcommunity.rndatetimepicker;
 
 import java.util.Calendar;
+
 import android.os.Bundle;
 
 public class RNDate {
-  private Calendar now;
+    private Calendar now;
 
-  public RNDate(Bundle args) {
-    now = Calendar.getInstance();
+    public RNDate(Bundle args) {
+        now = Calendar.getInstance();
 
-    if (args != null && args.containsKey(RNConstants.ARG_VALUE)) {
-      set(args.getLong(RNConstants.ARG_VALUE));
+        if (args != null && args.containsKey(RNConstants.ARG_VALUE)) {
+            set(args.getLong(RNConstants.ARG_VALUE));
+        }
     }
-  }
 
-  public void set(long value) {
-    now.setTimeInMillis(value);
-  }
+    public Calendar get() {
+        return now;
+    }
 
-  public int year() { return now.get(Calendar.YEAR); }
-  public int month() { return now.get(Calendar.MONTH); }
-  public int day() { return now.get(Calendar.DAY_OF_MONTH); }
-  public int hour() { return now.get(Calendar.HOUR_OF_DAY); }
-  public int minute() { return now.get(Calendar.MINUTE); }
+    public void set(long value) {
+        now.setTimeInMillis(value);
+    }
+
+    public int year() {
+        return now.get(Calendar.YEAR);
+    }
+
+    public int month() {
+        return now.get(Calendar.MONTH);
+    }
+
+    public int day() {
+        return now.get(Calendar.DAY_OF_MONTH);
+    }
+
+    public int hour() {
+        return now.get(Calendar.HOUR_OF_DAY);
+    }
+
+    public int minute() {
+        return now.get(Calendar.MINUTE);
+    }
+
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+
+        if (!(o instanceof RNDate)) {
+            return false;
+        }
+        RNDate otherDate = (RNDate) o;
+
+        return now.equals(otherDate.get());
+    }
 }

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
@@ -31,6 +31,9 @@ public class RNDatePickerDialogFragment extends DialogFragment {
   private DatePickerDialog instance;
 
   @Nullable
+  private RNDate date;
+
+  @Nullable
   private OnDateSetListener mOnDateSetListener;
   @Nullable
   private OnDismissListener mOnDismissListener;
@@ -40,12 +43,24 @@ public class RNDatePickerDialogFragment extends DialogFragment {
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
     Bundle args = getArguments();
+    date = new RNDate(args);
     instance = createDialog(args, getActivity(), mOnDateSetListener);
     return instance;
   }
 
   public void update(Bundle args) {
-    final RNDate date = new RNDate(args);
+    final RNDate newDate = new RNDate(args);
+
+    // React may rerender components whenever it feels like, even when props haven't changed.
+    // Calling update on the native android picker will always change its currently selected value.
+    // This happens even if the user has changed the selection in the picker.
+    // By only updating the selected value of the picker if it actually differs from last render,
+    // we avoid the user suddenly having their selection change seemingly randomly.
+    if (date != null && date.equals(newDate)) {
+      return;
+    }
+
+    date = newDate;
     instance.updateDate(date.year(), date.month(), date.day());
   }
 

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
@@ -29,6 +29,9 @@ public class RNTimePickerDialogFragment extends DialogFragment {
   private TimePickerDialog instance;
 
   @Nullable
+  private RNDate date;
+
+  @Nullable
   private OnTimeSetListener mOnTimeSetListener;
   @Nullable
   private OnDismissListener mOnDismissListener;
@@ -38,12 +41,24 @@ public class RNTimePickerDialogFragment extends DialogFragment {
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
     final Bundle args = getArguments();
+    date = new RNDate(args);
     instance = createDialog(args, getActivity(), mOnTimeSetListener);
     return instance;
   }
 
   public void update(Bundle args) {
-    final RNDate date = new RNDate(args);
+    final RNDate newDate = new RNDate(args);
+
+    // React may rerender components whenever it feels like, even when props haven't changed.
+    // Calling update on the native android picker will always change its currently selected value.
+    // This happens even if the user has changed the selection in the picker.
+    // By only updating the selected value of the picker if it actually differs from last render,
+    // we avoid the user suddenly having their selection change seemingly randomly.
+    if (date != null && date.equals(newDate)) {
+      return;
+    }
+
+    date = newDate;
     instance.updateTime(date.hour(), date.minute());
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
React may rerender components whenever it feels like, even when props haven't changed.
Calling update on the native android picker will always change its currently selected value.
This happens even if the user has changed the selection in the picker.
By only updating the selected value of the picker if it actually differs from last render,
we avoid the user suddenly having their selection change seemingly randomly.

iOS already has a debounce equivalent to this one implemented, where
only actually changed datetime values are forwarded to native
components, see RNDateTimePicker.m#setDate.

Closes #182
Closes #235

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

The bug is demonstrated by rendering a date or timepicker on android, and having the component rerender. rerendering can be triggered by calling a settimeout in render calling setstate , or calling a setinterval in the constructor setting state.

One can probably modify the example code from the README, adding the settimeout i added in render here.
Open the datepicker, change your value, and observe the value will be reset without you clicking anything. With this patch however, it will stop changing unless date is actually changed to a different value.
```
import React, {useState} from 'react';
import {View, Button, Platform} from 'react-native';
import DateTimePicker from '@react-native-community/datetimepicker';

export const App = () => {
  const [date, setDate] = useState(new Date(1598051730000));
  const [mode, setMode] = useState('date');
  const [show, setShow] = useState(false);

  const onChange = (event, selectedDate) => {
    const currentDate = selectedDate || date;
    setShow(Platform.OS === 'ios');
    setDate(currentDate);
  };

  const showMode = (currentMode) => {
    setShow(true);
    setMode(currentMode);
  };

  const showDatepicker = () => {
    showMode('date');
  };

  const showTimepicker = () => {
    showMode('time');
  };

  setTimeout(() => setDate(old => old), 1000);

  return (
    <View>
      <View>
        <Button onPress={showDatepicker} title="Show date picker!" />
      </View>
      <View>
        <Button onPress={showTimepicker} title="Show time picker!" />
      </View>
      {show && (
        <DateTimePicker
          testID="dateTimePicker"
          value={date}
          mode={mode}
          is24Hour={true}
          display="default"
          onChange={onChange}
        />
      )}
    </View>
  );
};
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅ ❌     |
| Android |    ✅ ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
