### PR TITLE
fix: dismiss android datepicker dialog upon unmount

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java
@@ -1,0 +1,29 @@
+package com.reactcommunity.rndatetimepicker;
+
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import com.facebook.react.bridge.Promise;
+
+public class Common {
+
+  public static void dismissDialog(FragmentActivity activity, String fragmentTag, Promise promise) {
+    if (activity == null) {
+      promise.reject(
+              RNConstants.ERROR_NO_ACTIVITY,
+              "Tried to close a " + fragmentTag + " dialog while not attached to an Activity");
+      return;
+    }
+
+    FragmentManager fragmentManager = activity.getSupportFragmentManager();
+    final DialogFragment oldFragment = (DialogFragment) fragmentManager.findFragmentByTag(fragmentTag);
+
+    boolean fragmentFound = oldFragment != null;
+    if (fragmentFound) {
+      oldFragment.dismiss();
+    }
+
+    promise.resolve(fragmentFound);
+  }
+}

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
@@ -22,6 +22,8 @@ import com.facebook.react.bridge.*;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.module.annotations.ReactModule;
 
+import static com.reactcommunity.rndatetimepicker.Common.dismissDialog;
+
 /**
  * {@link NativeModule} that allows JS to show a native date picker dialog and get called back when
  * the user selects a date.
@@ -85,23 +87,9 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void close(Promise promise) {
+  public void dismiss(Promise promise) {
     FragmentActivity activity = (FragmentActivity) getCurrentActivity();
-    if (activity == null) {
-      promise.reject(
-              RNConstants.ERROR_NO_ACTIVITY,
-              "Tried to close a DatePicker dialog while not attached to an Activity");
-      return;
-    }
-
-    FragmentManager fragmentManager = activity.getSupportFragmentManager();
-    final RNDatePickerDialogFragment oldFragment = (RNDatePickerDialogFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);
-
-    if (oldFragment != null) {
-      oldFragment.dismiss();
-    }
-
-    promise.resolve(null);
+    dismissDialog(activity, FRAGMENT_TAG, promise);
   }
   /**
    * Show a date picker dialog.

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
@@ -84,6 +84,25 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
     }
   }
 
+  @ReactMethod
+  public void close(Promise promise) {
+    FragmentActivity activity = (FragmentActivity) getCurrentActivity();
+    if (activity == null) {
+      promise.reject(
+              RNConstants.ERROR_NO_ACTIVITY,
+              "Tried to close a DatePicker dialog while not attached to an Activity");
+      return;
+    }
+
+    FragmentManager fragmentManager = activity.getSupportFragmentManager();
+    final RNDatePickerDialogFragment oldFragment = (RNDatePickerDialogFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);
+
+    if (oldFragment != null) {
+      oldFragment.dismiss();
+    }
+
+    promise.resolve(null);
+  }
   /**
    * Show a date picker dialog.
    *

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
@@ -84,6 +84,26 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void close(Promise promise) {
+    FragmentActivity activity = (FragmentActivity) getCurrentActivity();
+    if (activity == null) {
+      promise.reject(
+              RNConstants.ERROR_NO_ACTIVITY,
+              "Tried to close a TimePicker dialog while not attached to an Activity");
+      return;
+    }
+
+    FragmentManager fragmentManager = activity.getSupportFragmentManager();
+    final RNTimePickerDialogFragment oldFragment = (RNTimePickerDialogFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);
+
+    if (oldFragment != null) {
+      oldFragment.dismiss();
+    }
+
+    promise.resolve(null);
+  }
+
+  @ReactMethod
   public void open(@Nullable final ReadableMap options, Promise promise) {
 
     FragmentActivity activity = (FragmentActivity) getCurrentActivity();

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
@@ -23,6 +23,8 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
+import static com.reactcommunity.rndatetimepicker.Common.dismissDialog;
+
 /**
  * {@link NativeModule} that allows JS to show a native time picker dialog and get called back when
  * the user selects a time.
@@ -84,23 +86,9 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void close(Promise promise) {
+  public void dismiss(Promise promise) {
     FragmentActivity activity = (FragmentActivity) getCurrentActivity();
-    if (activity == null) {
-      promise.reject(
-              RNConstants.ERROR_NO_ACTIVITY,
-              "Tried to close a TimePicker dialog while not attached to an Activity");
-      return;
-    }
-
-    FragmentManager fragmentManager = activity.getSupportFragmentManager();
-    final RNTimePickerDialogFragment oldFragment = (RNTimePickerDialogFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);
-
-    if (oldFragment != null) {
-      oldFragment.dismiss();
-    }
-
-    promise.resolve(null);
+    dismissDialog(activity, FRAGMENT_TAG, promise);
   }
 
   @ReactMethod

--- a/example/App.js
+++ b/example/App.js
@@ -180,6 +180,26 @@ export const App = () => {
                 testID="neutralButtonLabelTextInput"
               />
             </View>
+
+            <View style={styles.header}>
+              <ThemedText style={{margin: 10, flex: 1}}>
+                [android] show and dismiss picker after 3 secs
+              </ThemedText>
+            </View>
+            <View style={styles.button}>
+              <Button
+                testID="showAndDismissPickerButton"
+                onPress={() => {
+                  setShow(true);
+                  setTimeout(() => {
+                    setShow(false);
+                  }, 3000);
+                }}
+                title="Show and dismiss picker!"
+              />
+            </View>
+
+
             <View style={styles.button}>
               <Button
                 testID="showPickerButton"

--- a/example/App.js
+++ b/example/App.js
@@ -199,7 +199,6 @@ export const App = () => {
               />
             </View>
 
-
             <View style={styles.button}>
               <Button
                 testID="showPickerButton"

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -68,7 +68,7 @@ describe('Example', () => {
     const dateText = getDateText();
 
     if (isIOS()) {
-      const testElement = element(getDateTimePickerIOS());
+      const testElement = getDateTimePickerIOS();
       await testElement.setColumnToValue(0, 'November');
       await testElement.setColumnToValue(1, '3');
       await testElement.setColumnToValue(2, '1800');

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -3,6 +3,8 @@ const {
   getDateText,
   elementById,
   elementByText,
+  getDateTimePickerIOS,
+  getDatePickerAndroid,
 } = require('./utils/matchers');
 const {
   userChangesMinuteValue,
@@ -10,7 +12,7 @@ const {
   userTapsCancelButtonAndroid,
   userTapsOkButtonAndroid,
 } = require('./utils/actions');
-const {isAndroid, isIOS} = require('./utils/utils');
+const {isAndroid, isIOS, wait} = require('./utils/utils');
 
 describe('Example', () => {
   beforeEach(async () => {
@@ -35,11 +37,9 @@ describe('Example', () => {
     await userOpensPicker({mode: 'date', display: 'default'});
 
     if (isIOS()) {
-      await expect(
-        element(by.type('UIPickerView').withAncestor(by.id('dateTimePicker'))),
-      ).toBeVisible();
+      await expect(getDateTimePickerIOS()).toBeVisible();
     } else {
-      await expect(element(by.type('android.widget.DatePicker'))).toBeVisible();
+      await expect(getDatePickerAndroid()).toBeVisible();
     }
   });
 
@@ -47,9 +47,7 @@ describe('Example', () => {
     await userOpensPicker({mode: 'date', display: 'default'});
 
     if (isIOS()) {
-      await expect(
-        element(by.type('UIPickerView').withAncestor(by.id('dateTimePicker'))),
-      ).toBeVisible();
+      await expect(getDateTimePickerIOS()).toBeVisible();
     } else {
       const testElement = element(
         by
@@ -70,9 +68,7 @@ describe('Example', () => {
     const dateText = getDateText();
 
     if (isIOS()) {
-      const testElement = element(
-        by.type('UIPickerView').withAncestor(by.id('dateTimePicker')),
-      );
+      const testElement = element(getDateTimePickerIOS());
       await testElement.setColumnToValue(0, 'November');
       await testElement.setColumnToValue(1, '3');
       await testElement.setColumnToValue(2, '1800');
@@ -96,9 +92,7 @@ describe('Example', () => {
     await userOpensPicker({mode: 'time', display: 'default'});
 
     if (isIOS()) {
-      await expect(
-        element(by.type('UIPickerView').withAncestor(by.id('dateTimePicker'))),
-      ).toBeVisible();
+      await expect(getDateTimePickerIOS()).toBeVisible();
     } else {
       await expect(element(by.type('android.widget.TimePicker'))).toBeVisible();
     }
@@ -108,9 +102,7 @@ describe('Example', () => {
     await userOpensPicker({mode: 'time', display: 'default'});
 
     if (isIOS()) {
-      await expect(
-        element(by.type('UIPickerView').withAncestor(by.id('dateTimePicker'))),
-      ).toBeVisible();
+      await expect(getDateTimePickerIOS()).toBeVisible();
     } else {
       await userChangesMinuteValue();
       await userTapsCancelButtonAndroid();
@@ -124,9 +116,7 @@ describe('Example', () => {
     const timeText = getTimeText();
 
     if (isIOS()) {
-      const testElement = element(
-        by.type('UIPickerView').withAncestor(by.id('dateTimePicker')),
-      );
+      const testElement = getDateTimePickerIOS();
       await testElement.setColumnToValue(0, '2');
       await testElement.setColumnToValue(1, '44');
       await testElement.setColumnToValue(2, 'PM');
@@ -147,6 +137,14 @@ describe('Example', () => {
 
     const dateText = getDateText();
     await expect(dateText).toHaveText('01/01/1970');
+  });
+
+  it(':android: when component unmounts, dialog is dismissed', async () => {
+    await elementById('showAndDismissPickerButton').tap();
+    await expect(getDatePickerAndroid()).toBeVisible();
+    await wait(3500);
+
+    await expect(getDatePickerAndroid()).toNotExist();
   });
 
   describe('given 5-minute interval', () => {
@@ -195,9 +193,7 @@ describe('Example', () => {
     it(':ios: picker should offer only options divisible by 5 (0, 5, 10,...)', async () => {
       await userOpensPicker({mode: 'time', display: 'spinner', interval: 5});
 
-      const testElement = element(
-        by.type('UIPickerView').withAncestor(by.id('dateTimePicker')),
-      );
+      const testElement = getDateTimePickerIOS();
       await testElement.setColumnToValue(0, '2');
       await testElement.setColumnToValue(2, 'PM');
       const timeText = getTimeText();

--- a/example/e2e/utils/matchers.js
+++ b/example/e2e/utils/matchers.js
@@ -2,10 +2,16 @@ const getTimeText = () => element(by.id('timeText'));
 const getDateText = () => element(by.id('dateText'));
 const elementById = (id) => element(by.id(id));
 const elementByText = (text) => element(by.text(text));
+const getDateTimePickerIOS = () =>
+  element(by.type('UIPickerView').withAncestor(by.id('dateTimePicker')));
+const getDatePickerAndroid = () =>
+  element(by.type('android.widget.DatePicker'));
 
 module.exports = {
   getTimeText,
   getDateText,
   elementById,
   elementByText,
+  getDateTimePickerIOS,
+  getDatePickerAndroid,
 };

--- a/example/e2e/utils/utils.js
+++ b/example/e2e/utils/utils.js
@@ -1,7 +1,10 @@
 const isAndroid = () => device.getPlatform() === 'android';
 const isIOS = () => device.getPlatform() === 'ios';
+const wait = async (time = 1000) =>
+  new Promise((resolve) => setTimeout(resolve, time));
 
 module.exports = {
   isAndroid,
   isIOS,
+  wait,
 };

--- a/src/datepicker.android.js
+++ b/src/datepicker.android.js
@@ -42,8 +42,8 @@ export default class DatePickerAndroid {
     return NativeModules.RNDatePickerAndroid.open(options);
   }
 
-  static async close(): Promise<null> {
-    return NativeModules.RNDatePickerAndroid.close();
+  static async dismiss(): Promise<boolean> {
+    return NativeModules.RNDatePickerAndroid.dismiss();
   }
 
   /**

--- a/src/datepicker.android.js
+++ b/src/datepicker.android.js
@@ -42,6 +42,10 @@ export default class DatePickerAndroid {
     return NativeModules.RNDatePickerAndroid.open(options);
   }
 
+  static async close(): Promise<null> {
+    return NativeModules.RNDatePickerAndroid.close();
+  }
+
   /**
    * A date has been selected.
    */

--- a/src/datetimepicker.android.js
+++ b/src/datetimepicker.android.js
@@ -70,7 +70,7 @@ export default function RNDateTimePicker(props: AndroidNativeProps) {
   useEffect(() => {
     // This effect runs on unmount, and will ensure the picker is closed.
     // This allows for controlling the opening state of the picker through declarative logic in jsx.
-    return () => (pickers[mode] ?? pickers[MODE_DATE]).close();
+    return () => (pickers[mode] ?? pickers[MODE_DATE]).dismiss();
   }, [mode]);
 
   picker.then(

--- a/src/datetimepicker.android.js
+++ b/src/datetimepicker.android.js
@@ -15,6 +15,7 @@ import {
 } from './constants';
 import pickers from './picker';
 import invariant from 'invariant';
+import {useEffect} from 'react';
 
 import type {AndroidEvent, AndroidNativeProps} from './types';
 
@@ -65,6 +66,12 @@ export default function RNDateTimePicker(props: AndroidNativeProps) {
       });
       break;
   }
+
+  useEffect(() => {
+    // This effect runs on unmount, and will ensure the picker is closed.
+    // This allows for controlling the opening state of the picker through declarative logic in jsx.
+    return () => (pickers[mode] ?? pickers[MODE_DATE]).close();
+  }, [mode]);
 
   picker.then(
     function resolve({action, day, month, year, minute, hour}) {

--- a/src/timepicker.android.js
+++ b/src/timepicker.android.js
@@ -40,8 +40,8 @@ export default class TimePickerAndroid {
     return NativeModules.RNTimePickerAndroid.open(options);
   }
 
-  static async close(): Promise<null> {
-    return NativeModules.RNDatePickerAndroid.close();
+  static async dismiss(): Promise<boolean> {
+    return NativeModules.RNDatePickerAndroid.dismiss();
   }
 
   /**

--- a/src/timepicker.android.js
+++ b/src/timepicker.android.js
@@ -40,6 +40,10 @@ export default class TimePickerAndroid {
     return NativeModules.RNTimePickerAndroid.open(options);
   }
 
+  static async close(): Promise<null> {
+    return NativeModules.RNDatePickerAndroid.close();
+  }
+
   /**
    * A time has been selected.
    */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
this replaces #326 because the author did not allow to push into his branch

I figured it was easier to do this separately than by reviews

original description:

> This commit makes the behavior of the android datetimepickers more in
line with other controlled components in react, where unmounting the
component actually dismisses the ui widget as well.

I also think it might be useful to have a way to dismiss android dialogs from JS and this will expose that possibility. The api will be documented later after we change the api of the android picker to an imperative one, as outlined in https://github.com/react-native-datetimepicker/datetimepicker/pull/327#issuecomment-723160992


## Test Plan

run demo app, click the "Show and dismiss picker!" button

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
- [x] I have added automated tests, either in JS or e2e tests, as applicable
