### PR TITLE
chore: add GH sponsors for organization

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: [vonovak]
+github: [react-native-datetimepicker]
 open_collective: react-native-datetimepicker


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

I have finally managed to set up GH sponsors for this organization (which included a bugfix from the sponsors team, so if you tried this before and it didn't work, now it might! 😄 ). It is done through opencollective but makes sponsoring more accessible to folks who have GH but don't want to create an account at opencollective.
