### PR TITLE
Add Windows Native Props Types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,7 @@ type AndroidMode = 'date' | 'time';
 type Display = 'spinner' | 'default' | 'clock' | 'calendar';
 type IOSDisplay = 'default' | 'compact' | 'inline' | 'spinner';
 type MinuteInterval = 1 | 2 | 3 | 4 | 5 | 6 | 10 | 12 | 15 | 20 | 30;
+type DAY_OF_WEEK = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
 export type Event = SyntheticEvent<
   Readonly<{
@@ -148,6 +149,40 @@ export type NativeRef = {
   current: Ref<RCTDateTimePickerNative> | null;
 };
 
-declare const RNDateTimePicker: FC<IOSNativeProps | AndroidNativeProps>;
+export type WindowsDatePickerChangeEvent = {
+  nativeEvent: {
+    newDate: number,
+  }
+}
+
+export type WindowsNativeProps = Readonly<
+  BaseProps &
+    DateOptions &
+    TimeOptions & {
+
+      /**
+       * The display options.
+       */
+      display?: Display;
+
+      onChange?: (event: WindowsDatePickerChangeEvent, date?: Date) => void;
+      placeholderText?:string,
+      dateFormat?:
+    | 'day month year'
+    | 'dayofweek day month'
+    | 'longdate'
+    | 'shortdate',
+  dayOfWeekFormat?:
+    | '{dayofweek.abbreviated(2)}'
+    | '{dayofweek.abbreviated(3)}'
+    | '{dayofweek.full}',
+    firstDayOfWeek?: DAY_OF_WEEK,
+    timeZoneOffsetInSeconds?: number,
+    is24Hour?: boolean,
+    minuteInterval?: number,
+    }
+>;
+
+declare const RNDateTimePicker: FC<IOSNativeProps | AndroidNativeProps | WindowsNativeProps>;
 
 export default RNDateTimePicker;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -151,38 +151,39 @@ export type NativeRef = {
 
 export type WindowsDatePickerChangeEvent = {
   nativeEvent: {
-    newDate: number,
-  }
-}
+    newDate: number;
+  };
+};
 
 export type WindowsNativeProps = Readonly<
   BaseProps &
     DateOptions &
     TimeOptions & {
-
       /**
        * The display options.
        */
       display?: Display;
 
       onChange?: (event: WindowsDatePickerChangeEvent, date?: Date) => void;
-      placeholderText?:string,
+      placeholderText?: string;
       dateFormat?:
-    | 'day month year'
-    | 'dayofweek day month'
-    | 'longdate'
-    | 'shortdate',
-  dayOfWeekFormat?:
-    | '{dayofweek.abbreviated(2)}'
-    | '{dayofweek.abbreviated(3)}'
-    | '{dayofweek.full}',
-    firstDayOfWeek?: DAY_OF_WEEK,
-    timeZoneOffsetInSeconds?: number,
-    is24Hour?: boolean,
-    minuteInterval?: number,
+        | 'day month year'
+        | 'dayofweek day month'
+        | 'longdate'
+        | 'shortdate';
+      dayOfWeekFormat?:
+        | '{dayofweek.abbreviated(2)}'
+        | '{dayofweek.abbreviated(3)}'
+        | '{dayofweek.full}';
+      firstDayOfWeek?: DAY_OF_WEEK;
+      timeZoneOffsetInSeconds?: number;
+      is24Hour?: boolean;
+      minuteInterval?: number;
     }
 >;
 
-declare const RNDateTimePicker: FC<IOSNativeProps | AndroidNativeProps | WindowsNativeProps>;
+declare const RNDateTimePicker: FC<
+  IOSNativeProps | AndroidNativeProps | WindowsNativeProps
+>;
 
 export default RNDateTimePicker;


### PR DESCRIPTION
# Summary

When building a typescript app that uses a DateTimePicker and running for Windows, typescript checks via `yarn tsc` fail for DateTimePicker props that are specific to Windows (i.e. dayOfWeekFormat, firstDayOfWeek, etc.). index.d.ts was missing type information for Windows Native Props. 

## Test Plan

To see issue add DateTimePicker to a typescript React Native Windows app. Add instance of DateTimePicker to App.js which uses a Windows only prop such as dayOfWeekFormat. Run `yarn tsc`. Error will show that 'dayOfWeekFormat' is not valid. 

To show issue is resolved replace old index.d.ts with new in DateTimePicker dir inside of app's node_modules folder. Run `yarn tsc` again and see check run clean. Then run app via `npx react-native run-windows` to show that component continues to render correctly without error.

### What's required for testing (prerequisites)?
Environment to support running a React Native Windows app. See [here](https://microsoft.github.io/react-native-windows/docs/rnw-dependencies).

### What are the steps to reproduce (after prerequisites)?
To see issue add DateTimePicker to a typescript React Native Windows app. Add instance of DateTimePicker to App.js which uses a Windows only prop such as dayOfWeekFormat. Run `yarn tsc`. Error will show that 'dayOfWeekFormat' is not valid. 

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| Windows |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
