### PR TITLE
Lifecycle addObserver crash fix | Android

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
@@ -117,16 +117,16 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
    *                dismiss, year, month and date are undefined.
    */
   @ReactMethod
-  public void open(@Nullable final ReadableMap options, Promise promise) {
+  public void open(@Nullable final ReadableMap options, final Promise promise) {
     FragmentActivity activity = (FragmentActivity) getCurrentActivity();
     if (activity == null) {
       promise.reject(
-          RNConstants.ERROR_NO_ACTIVITY,
-          "Tried to open a DatePicker dialog while not attached to an Activity");
+              RNConstants.ERROR_NO_ACTIVITY,
+              "Tried to open a DatePicker dialog while not attached to an Activity");
       return;
     }
 
-    FragmentManager fragmentManager = activity.getSupportFragmentManager();
+    final FragmentManager fragmentManager = activity.getSupportFragmentManager();
     final RNDatePickerDialogFragment oldFragment = (RNDatePickerDialogFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);
 
     if (oldFragment != null && options != null) {
@@ -140,17 +140,22 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
       return;
     }
 
-    RNDatePickerDialogFragment fragment = new RNDatePickerDialogFragment();
+    UiThreadUtil.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        RNDatePickerDialogFragment fragment = new RNDatePickerDialogFragment();
 
-    if (options != null) {
-      fragment.setArguments(createFragmentArguments(options));
-    }
+        if (options != null) {
+          fragment.setArguments(createFragmentArguments(options));
+        }
 
-    final DatePickerDialogListener listener = new DatePickerDialogListener(promise);
-    fragment.setOnDismissListener(listener);
-    fragment.setOnDateSetListener(listener);
-    fragment.setOnNeutralButtonActionListener(listener);
-    fragment.show(fragmentManager, FRAGMENT_TAG);
+        final DatePickerDialogListener listener = new DatePickerDialogListener(promise);
+        fragment.setOnDismissListener(listener);
+        fragment.setOnDateSetListener(listener);
+        fragment.setOnNeutralButtonActionListener(listener);
+        fragment.show(fragmentManager, FRAGMENT_TAG);
+      }
+    });
   }
 
   private Bundle createFragmentArguments(ReadableMap options) {

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
@@ -121,8 +121,8 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
     FragmentActivity activity = (FragmentActivity) getCurrentActivity();
     if (activity == null) {
       promise.reject(
-              RNConstants.ERROR_NO_ACTIVITY,
-              "Tried to open a DatePicker dialog while not attached to an Activity");
+        RNConstants.ERROR_NO_ACTIVITY,
+        "Tried to open a DatePicker dialog while not attached to an Activity");
       return;
     }
 

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
@@ -92,7 +92,7 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void open(@Nullable final ReadableMap options, Promise promise) {
+  public void open(@Nullable final ReadableMap options, final Promise promise) {
 
     FragmentActivity activity = (FragmentActivity) getCurrentActivity();
     if (activity == null) {
@@ -103,7 +103,7 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
     }
     // We want to support both android.app.Activity and the pre-Honeycomb FragmentActivity
     // (for apps that use it for legacy reasons). This unfortunately leads to some code duplication.
-    FragmentManager fragmentManager = activity.getSupportFragmentManager();
+    final FragmentManager fragmentManager = activity.getSupportFragmentManager();
     final RNTimePickerDialogFragment oldFragment = (RNTimePickerDialogFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);
 
     if (oldFragment != null && options != null) {
@@ -117,17 +117,22 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
       return;
     }
 
-    RNTimePickerDialogFragment fragment = new RNTimePickerDialogFragment();
+    UiThreadUtil.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        RNTimePickerDialogFragment fragment = new RNTimePickerDialogFragment();
 
-    if (options != null) {
-      fragment.setArguments(createFragmentArguments(options));
-    }
+        if (options != null) {
+          fragment.setArguments(createFragmentArguments(options));
+        }
 
-    final TimePickerDialogListener listener = new TimePickerDialogListener(promise);
-    fragment.setOnDismissListener(listener);
-    fragment.setOnTimeSetListener(listener);
-    fragment.setOnNeutralButtonActionListener(listener);
-    fragment.show(fragmentManager, FRAGMENT_TAG);
+        final TimePickerDialogListener listener = new TimePickerDialogListener(promise);
+        fragment.setOnDismissListener(listener);
+        fragment.setOnTimeSetListener(listener);
+        fragment.setOnNeutralButtonActionListener(listener);
+        fragment.show(fragmentManager, FRAGMENT_TAG);
+      }
+    });
   }
 
   private Bundle createFragmentArguments(ReadableMap options) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
What issues does the pull request solve?
This issue solves the error thrown in Android as follows:
`E/unknown:ReactNative: CatalystInstanceImpl caught native exception
    java.lang.IllegalStateException: Method addObserver must be called on the main thread
        at androidx.lifecycle.LifecycleRegistry.enforceMainThreadIfNeeded(LifecycleRegistry.java:317)
        at androidx.lifecycle.LifecycleRegistry.addObserver(LifecycleRegistry.java:172)
        at androidx.fragment.app.Fragment.initLifecycle(Fragment.java:496)
        at androidx.fragment.app.Fragment.<init>(Fragment.java:476)
        at androidx.fragment.app.DialogFragment.<init>(DialogFragment.java:138)
        at com.reactcommunity.rndatetimepicker.RNDatePickerDialogFragment.<init>(RNDatePickerDialogFragment.java:30)
        at com.reactcommunity.rndatetimepicker.RNDatePickerDialogModule.open(RNDatePickerDialogModule.java:143)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
        at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:151)
        at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method)
        at android.os.Handler.handleCallback(Handler.java:883)
        at android.os.Handler.dispatchMessage(Handler.java:100)
        at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
        at android.os.Looper.loop(Looper.java:214)
        at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:226)
        at java.lang.Thread.run(Thread.java:919)`

How did you implement the solution?
Changed implementation to open picker fragment on UI Thread.

What areas of the library does it impact?
Displaying the date / time picker on Android.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Library 'androidx.lifecycle:lifecycle-extensions' should be used.


### What are the steps to reproduce (after prerequisites)?
Open date or time picker

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅ ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
