### PR TITLE
Bump minimum OS version to match Xcode support

### DIFF
--- a/RNDateTimePicker.podspec
+++ b/RNDateTimePicker.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package['license']
   s.author       = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, "9.0"
+  s.platform     = :ios, "10.0"
   s.source       = { :git => "https://github.com/react-native-community/datetimepicker", :tag => "v#{s.version}" }
   s.source_files = "ios/*.{h,m}"
   s.requires_arc = true

--- a/RNDateTimePicker.podspec
+++ b/RNDateTimePicker.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package['license']
   s.author       = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, "8.0"
+  s.platform     = :ios, "9.0"
   s.source       = { :git => "https://github.com/react-native-community/datetimepicker", :tag => "v#{s.version}" }
   s.source_files = "ios/*.{h,m}"
   s.requires_arc = true


### PR DESCRIPTION
# Summary

When running a build on the command line, I get the following warning:
```
warning: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.2.99. (in target 'RNDateTimePicker' from project 'Pods')
```

Since the recent iOS minimum for React Native is 9.0, I updated the .podspec to match it.

## Test Plan

1. Updated the podspec in my application's `node_modules` folder.
2. Ran an Xcode build.
3. Verified no warnings about `IPHONEOS_DEPLOYMENT_TARGET`

### What's required for testing (prerequisites)?
N/A

### What are the steps to reproduce (after prerequisites)?
N/A

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    N/A     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
