### PR TITLE
chore: wait to avoid e2e android flakiness

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -193,7 +193,7 @@ export const App = () => {
                   setShow(true);
                   setTimeout(() => {
                     setShow(false);
-                  }, 3000);
+                  }, 5000);
                 }}
                 title="Show and dismiss picker!"
               />

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -141,8 +141,9 @@ describe('Example', () => {
 
   it(':android: when component unmounts, dialog is dismissed', async () => {
     await elementById('showAndDismissPickerButton').tap();
+    await wait(2000);
     await expect(getDatePickerAndroid()).toBeVisible();
-    await wait(3500);
+    await wait(5000);
 
     await expect(getDatePickerAndroid()).toNotExist();
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

there is an android e2e test that is flaky, this should help albeit not nice

## Test Plan

android e2e tests pass repeatedly

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅ ❌     |
| Android |    ✅ ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [x] I have added automated tests, either in JS or e2e tests, as applicable
