### PR TITLE
add forwardRef prop to support forwardRef & createAnimatedComponent

### DIFF
--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -57,7 +57,7 @@ export default function Picker({
   ...otherProps
 }: IOSNativeProps) {
   const [heightStyle, setHeightStyle] = useState(undefined);
-  const _picker: NativeRef = forwardRef || React.useRef();
+  const _picker: NativeRef = React.useRef();
   const display = getDisplaySafe(otherProps.display);
 
   useEffect(
@@ -110,7 +110,7 @@ export default function Picker({
   return (
     <RNDateTimePicker
       testID={testID}
-      ref={_picker}
+      ref={forwardRef || _picker}
       style={StyleSheet.compose(heightStyle, style)}
       date={dates.value}
       locale={locale !== null && locale !== '' ? locale : undefined}

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -53,10 +53,11 @@ export default function Picker({
   timeZoneOffsetInMinutes,
   textColor,
   onChange,
+  forwardRef,
   ...otherProps
 }: IOSNativeProps) {
   const [heightStyle, setHeightStyle] = useState(undefined);
-  const _picker: NativeRef = React.useRef();
+  const _picker: NativeRef = forwardRef || React.useRef();
   const display = getDisplaySafe(otherProps.display);
 
   useEffect(


### PR DESCRIPTION
# Summary
to solve issue [309](https://github.com/react-native-datetimepicker/datetimepicker/issues/309)

add forwardRef prop to support React.forwardRef, to make DateTimePicker an animatable component.

## Test Plan

`
const _DateTimePicker = React.forwardRef((props, ref) => (
  <DateTimePicker forwardRef={ref} {...props} />
));`
`const AnimatedDateTimePicker = Animated.createAnimatedComponent(_DateTimePicker);
`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
