### PR TITLE
chore: fix ios run script

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -193,7 +193,7 @@ export const App = () => {
                   setShow(true);
                   setTimeout(() => {
                     setShow(false);
-                  }, 5000);
+                  }, 6000);
                 }}
                 title="Show and dismiss picker!"
               />

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -141,9 +141,9 @@ describe('Example', () => {
 
   it(':android: when component unmounts, dialog is dismissed', async () => {
     await elementById('showAndDismissPickerButton').tap();
-    await wait(2000);
-    await expect(getDatePickerAndroid()).toBeVisible();
-    await wait(5000);
+    await wait(3000);
+    await expect(getDatePickerAndroid()).toExist();
+    await wait(6000);
 
     await expect(getDatePickerAndroid()).toNotExist();
   });

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -294,8 +294,8 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/callinvoker (= 0.62.2)
-  - RNDateTimePicker (3.0.0):
-    - React
+  - RNDateTimePicker (3.0.9):
+    - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -459,10 +459,10 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  RNDateTimePicker: f47a6309133c6d013ad6942fc83b753b3f6e41d6
+  RNDateTimePicker: 8a51a2216c307769e69ef827293d59549ab1ca23
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 76457826527484be7d45f7d1139a00e91de6c831
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.1

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "start": "react-native start",
     "start:android": "react-native run-android --no-jetifier",
-    "start:ios": "react-native run-ios",
+    "start:ios": "react-native run-ios --project-path example/ios",
     "start:windows": "react-native start --use-react-native-windows",
     "test": "jest ./test",
     "posttest": "npm run lint",

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -17,7 +17,7 @@ module.exports = {
 const windowsSwitch = '--use-react-native-windows';
 
 if (process.argv.includes(windowsSwitch)) {
-  process.argv = process.argv.filter(arg => arg !== windowsSwitch);
+  process.argv = process.argv.filter((arg) => arg !== windowsSwitch);
   process.argv.push('--config=metro.config.windows.js');
   module.exports = {
     reactNativePath: 'node_modules/react-native-windows',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

this fixes the ios run script `yarn start:ios` which would previously fail with an error
## Test Plan

`start:android` and `start:ios` yarn scripts work

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
