### PR TITLE
add disabled support for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ React Native date & time picker component for iOS, Android and Windows.
     - [`neutralButtonLabel` (`optional`, `Android only`)](#neutralbuttonlabel-optional-android-only)
     - [`minuteInterval` (`optional`)](#minuteinterval-optional)
     - [`style` (`optional`, `iOS only`)](#style-optional-ios-only)
+    - [`disabled` (`optional`, `iOS only`)](#disabled-optional-ios-only)
   - [Migration from the older components](#migration-from-the-older-components)
     - [DatePickerIOS](#datepickerios)
     - [DatePickerAndroid](#datepickerandroid)
@@ -359,6 +360,10 @@ This means that eg. if the device has dark mode turned on, and your screen backg
 ```js
 <RNDateTimePicker style={{flex: 1}} />
 ```
+
+#### `disabled` (`optional`, `iOS only`)
+
+If true the user won't be able to toggle the switch.
 
 ## Migration from the older components
 

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ This means that eg. if the device has dark mode turned on, and your screen backg
 
 #### `disabled` (`optional`, `iOS only`)
 
-If true the user won't be able to toggle the switch.
+If true, the user won't be able to interact with the view.
 
 ## Migration from the older components
 

--- a/example/App.js
+++ b/example/App.js
@@ -9,6 +9,7 @@ import {
   Platform,
   TextInput,
   useColorScheme,
+  Switch,
 } from 'react-native';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import SegmentedControl from '@react-native-community/segmented-control';
@@ -67,6 +68,7 @@ export const App = () => {
   const [display, setDisplay] = useState(DISPLAY_VALUES[0]);
   const [interval, setMinInterval] = useState(1);
   const [neutralButtonLabel, setNeutralButtonLabel] = useState(undefined);
+  const [disabled, setDisabled] = useState(false);
 
   // Windows-specific
   const [time, setTime] = useState(undefined);
@@ -171,6 +173,12 @@ export const App = () => {
             </View>
             <View style={styles.header}>
               <ThemedText style={{margin: 10, flex: 1}}>
+                disabled (iOS only)
+              </ThemedText>
+              <Switch value={disabled} onValueChange={setDisabled} />
+            </View>
+            <View style={styles.header}>
+              <ThemedText style={{margin: 10, flex: 1}}>
                 neutralButtonLabel (android only)
               </ThemedText>
               <ThemedTextInput
@@ -257,6 +265,7 @@ export const App = () => {
                 style={styles.iOsPicker}
                 textColor={color || undefined}
                 neutralButtonLabel={neutralButtonLabel}
+                disabled={disabled}
               />
             )}
           </View>

--- a/ios/RNDateTimePickerManager.m
+++ b/ios/RNDateTimePickerManager.m
@@ -118,4 +118,13 @@ RCT_CUSTOM_VIEW_PROPERTY(displayIOS, UIDatePickerStyle, RNDateTimePicker)
     }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(disabled, BOOL, RNDateTimePicker)
+{
+  if (json) {
+    view.enabled = !([RCTConvert BOOL:json]);
+  } else {
+    view.enabled = defaultView.enabled;
+  }
+}
+
 @end

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -53,6 +53,7 @@ export default function Picker({
   timeZoneOffsetInMinutes,
   textColor,
   onChange,
+  disabled,
   ...otherProps
 }: IOSNativeProps) {
   const [heightStyle, setHeightStyle] = useState(undefined);
@@ -123,6 +124,7 @@ export default function Picker({
       onStartShouldSetResponder={() => true}
       onResponderTerminationRequest={() => false}
       displayIOS={display}
+      disabled={disabled !== true}
     />
   );
 }

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -53,7 +53,7 @@ export default function Picker({
   timeZoneOffsetInMinutes,
   textColor,
   onChange,
-  disabled,
+  disabled = false,
   ...otherProps
 }: IOSNativeProps) {
   const [heightStyle, setHeightStyle] = useState(undefined);
@@ -124,7 +124,7 @@ export default function Picker({
       onStartShouldSetResponder={() => true}
       onResponderTerminationRequest={() => false}
       displayIOS={display}
-      disabled={disabled !== true}
+      disabled={disabled === true}
     />
   );
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -100,6 +100,11 @@ export type IOSNativeProps = Readonly<
      * Sets the preferredDatePickerStyle for picker
      */
     display?: IOSDisplay;
+
+    /**
+     * Is this picker disabled?
+     */
+    disabled?: boolean;
   }
 >;
 

--- a/src/types.js
+++ b/src/types.js
@@ -121,7 +121,7 @@ export type IOSNativeProps = $ReadOnly<{|
   display?: IOSDisplay,
 
   /**
-   * Is this control disabled?
+   * Is this picker disabled?
    */
   disabled?: boolean,
 |}>;

--- a/src/types.js
+++ b/src/types.js
@@ -119,6 +119,11 @@ export type IOSNativeProps = $ReadOnly<{|
    * Sets the preferredDatePickerStyle for picker
    */
   display?: IOSDisplay,
+
+  /**
+   * Is this control disabled?
+   */
+  disabled?: boolean,
 |}>;
 
 export type AndroidNativeProps = $ReadOnly<{|

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`DatePicker applies styling to DatePicker 1`] = `
 <RNDateTimePicker
   date={1376949600000}
+  disabled={false}
   displayIOS="default"
   mode="date"
   onChange={[Function]}
@@ -24,6 +25,7 @@ exports[`DatePicker applies styling to DatePicker 1`] = `
 exports[`DatePicker renders a native Component 1`] = `
 <RNDateTimePicker
   date={1376949600000}
+  disabled={false}
   displayIOS="default"
   mode="date"
   onChange={[Function]}
@@ -40,6 +42,7 @@ exports[`DatePicker renders a native Component 1`] = `
 exports[`DatePicker renders with mode countdown 1`] = `
 <RNDateTimePicker
   date={1376949600000}
+  disabled={false}
   displayIOS="default"
   mode="countdown"
   onChange={[Function]}
@@ -56,6 +59,7 @@ exports[`DatePicker renders with mode countdown 1`] = `
 exports[`DatePicker renders with mode datetime 1`] = `
 <RNDateTimePicker
   date={1376949600000}
+  disabled={false}
   displayIOS="default"
   mode="datetime"
   onChange={[Function]}
@@ -72,6 +76,7 @@ exports[`DatePicker renders with mode datetime 1`] = `
 exports[`DatePicker renders with mode time 1`] = `
 <RNDateTimePicker
   date={1376949600000}
+  disabled={false}
   displayIOS="default"
   mode="time"
   onChange={[Function]}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Adds ability to disable this control on iOS.

ref #303

## Test Plan

Added ability to toggle to example app

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
- [x] I have added automated tests, either in JS or e2e tests, as applicable
