### PR TITLE
fix android e2e test

### DIFF
--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -199,7 +199,7 @@ describe('Example', () => {
 
   it(':android: when component unmounts, dialog is dismissed', async () => {
     await elementById('showAndDismissPickerButton').tap();
-    await wait(3000);
+    await wait(1000);
     await expect(getDatePickerAndroid()).toExist();
     await wait(6000);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
The `android.widget.DatePicker` is disappearing from the screen after 3 seconds and the e2e tests are failing
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

e2e tests are running ok

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [x] I have added automated tests, either in JS or e2e tests, as applicable
