### PR TITLE
Fix time being reset to 0:00 when date changes on Android

### DIFF
--- a/src/datetimepicker.android.js
+++ b/src/datetimepicker.android.js
@@ -124,7 +124,6 @@ export default function RNDateTimePicker(props: AndroidNativeProps) {
           switch (action) {
             case DATE_SET_ACTION:
               date.setFullYear(year, month, day);
-              date.setHours(0, 0);
               date = timeZoneOffsetDateSetter(date, timeZoneOffsetInMinutes);
               event.nativeEvent.timestamp = date;
               onChange(event, date);


### PR DESCRIPTION
# Summary

There was a change in v3.4.0 (https://github.com/react-native-datetimepicker/datetimepicker/pull/407) that inadvertently caused the time to be set to 0:00 whenever the date is set on Android.

## Test Plan

Tested in my app using patch-package.

Applying this patch restores the pre-v3.4.0 behaviour where the time is preserved when the date is changed on Android, making it consistent once again with iOS.

## Checklist

- [x] I have tested this on a device and a simulator
