### PR TITLE
Fix for RN Spinner not working right on newer Android devices

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDismissableDatePickerDialog.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDismissableDatePickerDialog.java
@@ -65,7 +65,7 @@ public class RNDismissableDatePickerDialog extends DatePickerDialog {
   }
 
   private void fixSpinner(Context context, int year, int month, int dayOfMonth, RNDatePickerDisplay display) {
-    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N && display == RNDatePickerDisplay.SPINNER) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && display == RNDatePickerDisplay.SPINNER) {
       try {
         // Get the theme's android:datePickerMode
         Class<?> styleableClass = Class.forName("com.android.internal.R$styleable");

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDismissableTimePickerDialog.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDismissableTimePickerDialog.java
@@ -71,7 +71,7 @@ public class RNDismissableTimePickerDialog extends MinuteIntervalSnappableTimePi
   }
 
   private void fixSpinner(Context context, int hourOfDay, int minute, boolean is24HourView, RNTimePickerDisplay display) {
-    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N && display == RNTimePickerDisplay.SPINNER) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && display == RNTimePickerDisplay.SPINNER) {
       try {
         Class<?> styleableClass = Class.forName("com.android.internal.R$styleable");
         Field timePickerStyleableField = styleableClass.getField("TimePicker");


### PR DESCRIPTION
Clean PR

#411

This fixes the issue for me. It shows spinner on time. I think when Build.VERSION_CODES.N came it it made sense to use ==, but now there are a ton of newer versions.

`if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && display == RNDatePickerDisplay.SPINNER) {`