### PR TITLE
Remove dependency on upstream RN styles for SpinnerTimePickerDialog and SpinnerTimePickerStyle

### DIFF
--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,0 +1,8 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="SpinnerTimePickerDialog" parent="Theme.AppCompat.Light.Dialog" tools:targetApi="lollipop">
+        <item name="android:timePickerStyle">@style/SpinnerTimePickerStyle</item>
+    </style>
+    <style name="SpinnerTimePickerStyle" parent="android:Widget.Material.Light.TimePicker" tools:targetApi="lollipop">
+        <item name="android:timePickerMode">spinner</item>
+    </style>
+</resources>


### PR DESCRIPTION
Resolves #411.

Closes #258

Changes tested in the sample repo (https://github.com/klandell/time-spinner-bug)  in both the main and rn-64 branches on a physical Android device.