### PR TITLE
Fix Android timezone issues

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDate.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDate.java
@@ -9,14 +9,16 @@ public class RNDate {
 
   public RNDate(Bundle args) {
     now = Calendar.getInstance();
-    if (args != null && args.containsKey(RNConstants.ARG_TZOFFSET_MINS)) {
-      now.setTimeZone(TimeZone.getTimeZone("GMT"));
-      Integer timeZoneOffsetInMinutes = args.getInt(RNConstants.ARG_TZOFFSET_MINS);
-      now.add(Calendar.MILLISECOND, timeZoneOffsetInMinutes * 60000);
-    }
 
     if (args != null && args.containsKey(RNConstants.ARG_VALUE)) {
       set(args.getLong(RNConstants.ARG_VALUE));
+    }
+
+    if (args != null && args.containsKey(RNConstants.ARG_TZOFFSET_MINS)) {
+      now.setTimeZone(TimeZone.getTimeZone("GMT"));
+      Long timeZoneOffsetInMinutesFallback = args.getLong(RNConstants.ARG_TZOFFSET_MINS);
+      Integer timeZoneOffsetInMinutes = args.getInt(RNConstants.ARG_TZOFFSET_MINS, timeZoneOffsetInMinutesFallback.intValue());
+      now.add(Calendar.MILLISECOND, timeZoneOffsetInMinutes * 60000);
     }
   }
 

--- a/src/datetimepicker.android.js
+++ b/src/datetimepicker.android.js
@@ -66,10 +66,7 @@ function getPicker({
 
 function timeZoneOffsetDateSetter(date, timeZoneOffsetInMinutes) {
   let localDate = date;
-  if (
-    typeof timeZoneOffsetInMinutes !== 'undefined' &&
-    timeZoneOffsetInMinutes >= 0
-  ) {
+  if (typeof timeZoneOffsetInMinutes === 'number') {
     const offset =
       localDate.getTimezoneOffset() * MIN_MS + timeZoneOffsetInMinutes * MIN_MS;
     localDate = new Date(date.getTime() - offset);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
I have find out issue while using datetime picker for RN App with timezone handling.
I need to use fixed timezone through whole app. As I found out, from last releases datetime picker should not be device timezone dependent if you've passed `timeZoneOffsetInMinutes` prop into `DateTimePicker` component (as the docs says). iOS works really well, but as it turns out, Android is not so good. (To be correct it doesn't apply timezone in some cases at all 😄). This proposal should fix that issue for Android. (At least it works for us). (I will describe steps to reproduce and technical source of the issue below)

- It's impact Android only
- It's related to timeZoneOffsetInMinutes feature

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
### Display initially passed date (input)
- (timezones: `device: GMT +3`, `app: GMT -7`)
- pass `2021-04-09T17:00:00.000Z` date (for UTC it stands for 17:00, but for app timezone `-7` it should be treated like `10:00`)
- pass `timeZoneOffsetInMinutes={-420}` prop (`-420 = -7 * 60`)
- **Expected:** `TimePicker` should display `10:00` as initial selected date
- **Actual:** `TimePicker` displays `17:00` as initial selected date
According to this fact we can suppose what `timeZoneOffsetInMinutes` prop is ignored and UTC hours & minutes are displayed instead.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
- App uses fixed timezone for date handling/management (for example `GMT -7`)
- Device timezone should differ from app timezone (`device: GMT +3`, `app: GMT -7`)
- Android 🙂

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Affected |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅   |

### Changes Motivation
#### RNDate.java
- I have changed Custom Date initialization logic (set date in milliseconds at first, and only after that apply timezone)
- For some unknown reasons `timeZoneOffsetInMinutes` type acts randomly. In one case it's `Integer` type, in other case it's `Long` type. So I applied `Long` Java type compatibility (fallback for `getInt`).

#### datetimepicker.android.js
- I have refactored `if` statement for `timeZoneOffsetDateSetter` function which is called for time settings after promise from native Android method is resolved. I really don't get any reasons for ignoring negative `timeZoneOffsetInMinutes` value. (even docs showing example with `GMT -7 = - 420 minutes`)

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on my Android device and a emulator from Android Studio
