### PR TITLE
fix: classCastException on Huawei devices with android 7.0 (#329)

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/MinuteIntervalSnappableTimePickerDialog.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/MinuteIntervalSnappableTimePickerDialog.java
@@ -147,7 +147,7 @@ class MinuteIntervalSnappableTimePickerDialog extends TimePickerDialog {
         runnable = new Runnable() {
             @Override
             public void run() {
-                // set valid hour &  minutes
+                // set valid hour & minutes
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     view.setHour(hourOfDay);
                     view.setMinute(correctedMinutes);
@@ -159,13 +159,12 @@ class MinuteIntervalSnappableTimePickerDialog extends TimePickerDialog {
                 }
                 if (pickerIsInTextInputMode()) {
                     // move caret to the end of input
-                    try {
-                        final EditText textInput = (EditText) view.findFocus();
+                    View maybeTextInput = view.findFocus();
+                    if (maybeTextInput instanceof EditText) {
+                        final EditText textInput = (EditText) maybeTextInput;
                         textInput.setSelection(textInput.getText().length());
-                    } catch (ClassCastException exception) {
-                        if (exception.getMessage() != null) {
-                            Log.e("react-native-datetimepicker", exception.getMessage());
-                        }
+                    } else {
+                        Log.e("RN-datetimepicker", "could not set selection on time picker, this is a known issue on some Huawei devices");
                     }
                 }
             }

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/MinuteIntervalSnappableTimePickerDialog.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/MinuteIntervalSnappableTimePickerDialog.java
@@ -7,7 +7,9 @@ import android.annotation.SuppressLint;
 import android.app.TimePickerDialog;
 import android.content.DialogInterface;
 import android.content.Context;
+import android.os.Build;
 import android.os.Handler;
+import android.util.Log;
 import android.widget.TimePicker;
 import android.view.View;
 import android.widget.EditText;
@@ -141,22 +143,30 @@ class MinuteIntervalSnappableTimePickerDialog extends TimePickerDialog {
      */
     private void correctEnteredMinutes(final TimePicker view, final int hourOfDay, final int correctedMinutes) {
         assertNotSpinner("spinner never needs to be corrected because wrong values are not offered to user (both in scrolling and textInput mode)!");
-        final EditText textInput = (EditText) view.findFocus();
-
         // 'correction' callback
         runnable = new Runnable() {
             @Override
             public void run() {
-                if (pickerIsInTextInputMode()) {
-                    // set valid minutes && move caret to the end of input
-                    view.setCurrentHour(hourOfDay);
-                    view.setCurrentMinute(correctedMinutes);
-                    textInput.setSelection(textInput.getText().length());
+                // set valid hour &  minutes
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    view.setHour(hourOfDay);
+                    view.setMinute(correctedMinutes);
                 } else {
                     view.setCurrentHour(hourOfDay);
                     // we need to set minutes to 0 for this to work on older android devices
                     view.setCurrentMinute(0);
                     view.setCurrentMinute(correctedMinutes);
+                }
+                if (pickerIsInTextInputMode()) {
+                    // move caret to the end of input
+                    try {
+                        final EditText textInput = (EditText) view.findFocus();
+                        textInput.setSelection(textInput.getText().length());
+                    } catch (ClassCastException exception) {
+                        if (exception.getMessage() != null) {
+                            Log.e("react-native-datetimepicker", exception.getMessage());
+                        }
+                    }
                 }
             }
         };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
This fixes https://github.com/react-native-datetimepicker/datetimepicker/issues/329.

All changes were made in the file `MinuteIntervalSnappableTimePickerDialog.java`.

When minuteInterval was set on Huawei devices running android 7.0, a ClassCasteException was thrown, causing the app to crash. 

I surrounded the crashing code in `try...catch` and added logging for this specific error. 

Devices running android M and above now no longer use the deprecated functions `setCurrentHour();` and `setCurrentMinute();`.

## Test Plan

tested this on 
* Samsung Galaxy S10 
* android 7.0 emulator
* android 11.0 emulator

### What's required for testing (prerequisites)?

To test/find the bug, a Huawei device running android 7.0 is needed.
To test the new implementation, any android will do. 

### What are the steps to reproduce (after prerequisites)?

use the datetimepicker with a minuteInterval set. 

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
