### PR TITLE
chore: refer to android styles directly by ID

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
@@ -75,16 +75,12 @@ public class RNTimePickerDialogFragment extends DialogFragment {
       switch (display) {
         case CLOCK:
         case SPINNER:
-          String resourceName = display == RNTimePickerDisplay.CLOCK
-                  ? "ClockTimePickerDialog"
-                  : "SpinnerTimePickerDialog";
+          int theme = display == RNTimePickerDisplay.CLOCK
+                  ? R.style.ClockTimePickerDialog
+                  : R.style.SpinnerTimePickerDialog;
           return new RNDismissableTimePickerDialog(
                   activityContext,
-                  activityContext.getResources().getIdentifier(
-                          resourceName,
-                          "style",
-                          activityContext.getPackageName()
-                  ),
+                  theme,
                   onTimeSetListener,
                   hour,
                   minute,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

this is a follow up on https://github.com/react-native-datetimepicker/datetimepicker/pull/424

instead of getting styles by name, we're getting them directly by id

## Test Plan

tested manually on device

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
