### PR TITLE
fix: dismiss android time picker on unmount

### DIFF
--- a/src/timepicker.android.js
+++ b/src/timepicker.android.js
@@ -41,7 +41,7 @@ export default class TimePickerAndroid {
   }
 
   static async dismiss(): Promise<boolean> {
-    return NativeModules.RNDatePickerAndroid.dismiss();
+    return NativeModules.RNTimePickerAndroid.dismiss();
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

fixes #432

## Test Plan

tested manually with example app

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
