### PR TITLE
Revert "chore: refer to android styles directly by ID"

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
@@ -75,12 +75,16 @@ public class RNTimePickerDialogFragment extends DialogFragment {
       switch (display) {
         case CLOCK:
         case SPINNER:
-          int theme = display == RNTimePickerDisplay.CLOCK
-                  ? R.style.ClockTimePickerDialog
-                  : R.style.SpinnerTimePickerDialog;
+          String resourceName = display == RNTimePickerDisplay.CLOCK
+                  ? "ClockTimePickerDialog"
+                  : "SpinnerTimePickerDialog";
           return new RNDismissableTimePickerDialog(
                   activityContext,
-                  theme,
+                  activityContext.getResources().getIdentifier(
+                          resourceName,
+                          "style",
+                          activityContext.getPackageName()
+                  ),
                   onTimeSetListener,
                   hour,
                   minute,


### PR DESCRIPTION
Reverts react-native-datetimepicker/datetimepicker#435 which was done prematurely

Closes #437