### PR TITLE
Do not animate set date

### DIFF
--- a/ios/RNDateTimePicker.m
+++ b/ios/RNDateTimePicker.m
@@ -54,7 +54,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (void)setDate:(NSDate *)date {
     // Need to avoid the case where values coming back through the bridge trigger a new valueChanged event
     if (![self.date isEqualToDate:date]) {
-        [super setDate:date];
+        [super setDate:date animated:NO];
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

<!--
Explain the **motivation** for making this change: here are some points to help you:

# Summary

* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
The aim of this PR is to fix an issue that has been previously reported here: https://github.com/react-native-datetimepicker/datetimepicker/issues/192

After the last fix this may still happen. The picker gets back to the previously selected value if the user changes the picker very quickly. This happens specially on slow devices. I had to use an iPad Mini 2 for being able to reproduce it.

The problem seems to appear when the `setDate` is called again through the bridge after the callback was called in the native side of the things. (Native Event -> Native callback -> bridge -> RN rerender -> RN setsDate -> bridge -> Native setDate).
If before the Native setDate is called back, the user already started to edit the value again the bug will appear, when the Native Event is called again (when the user stops interacting with the picker) this will return the value that it just received from the last setDate.

As descibed here: https://developer.apple.com/documentation/uikit/uidatepicker/1615975-date?language=objc `setDate` is animated by default. This adds extra complexity since more asynchronous events are added to the equation. By disabling the animation the problem seems to be fixed. Unfortunately I can not go deeper in why that Native event returns the wrong `self.date `under those circumstances because there is no way, at least that I know, to debug instance property from parents in Objective-C. So I can not be certain where that value is coming from.

IMO, this issue is happening because of how different React and iOS UIViews patterns are. The UIDatePicker is not meant to be rehydrated with the value it has been selected just an instant ago. The picker is owner of it's own state so I believe that a proper solucion would be isolating the `setDate` from the `defaultValue`. Meaning that 2 different props are exposed, one for defaulting the value when the component is rendered and the other only used if updates are required. Then library clients could use the defaultValue to initialise the component and use the `setDate`only if an external update is required.
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |   ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
