### PR TITLE
fix android show dialog when date before 1900-01-01

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
@@ -149,7 +149,11 @@ public class RNDatePickerDialogFragment extends DialogFragment {
       c.set(Calendar.MILLISECOND, 999);
       datePicker.setMaxDate(c.getTimeInMillis());
     }
-
+    final RNDate date = new RNDate(args);
+    final int year = date.year();
+    final int month = date.month();
+    final int day = date.day();
+    datePicker.init(year,month,day, dialog);
     return dialog;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
When select date before 1900-01-01, then reselect date, the dialog will show the date is 1900-01-01
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
```tsx
<DateTimePicker
    mode={'date'}
    onChange={(event, date) => console.log(date)}
    value={new Date(1870, 1, 1, 0, 0, 0)}
/>
```
![image](https://user-images.githubusercontent.com/43195241/115817321-d12b8400-a424-11eb-9c6a-fc3797bb1631.png)

## Compatibility


| OS      | Implemented |
| ------- | :---------: |
| Android |    ✅    |



