### PR TITLE
remove unneccessaries from pch to reduce size and fix storage quote i…

### DIFF
--- a/windows/DateTimePickerWindows/pch.h
+++ b/windows/DateTimePickerWindows/pch.h
@@ -6,5 +6,3 @@
 #define NOMINMAX
 
 #include <unknwn.h>
-#include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.Foundation.Collections.h>


### PR DESCRIPTION
# Summary
The Azure DevOps hosted build agents are documented to be limited to 10GB (empirically ~13GB).  With my project and multiple community module PCH files building to between 100MB to 1.2GB, that space goes fast.  This PR reduces the PCH for datetimepicker from 102MB down to 13MB.

## Test Plan
- Ensure the code builds and the PCH file size is reduced.
- Include updated module in production project, publish to update website via CI/CD build, ensure build completes without error
- Update app on Surface Tablet and ensure all behaviors continue to work as expected.

### What's required for testing (prerequisites)?
- Windows development environment

### What are the steps to reproduce (after prerequisites)?
- build module and notice pch.pch is ~102MB (for x86)

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
