### PR TITLE
Fixed Android timezone issues and corresponding e2e test

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDate.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDate.java
@@ -9,14 +9,16 @@ public class RNDate {
 
   public RNDate(Bundle args) {
     now = Calendar.getInstance();
-    if (args != null && args.containsKey(RNConstants.ARG_TZOFFSET_MINS)) {
-      now.setTimeZone(TimeZone.getTimeZone("GMT"));
-      Integer timeZoneOffsetInMinutes = args.getInt(RNConstants.ARG_TZOFFSET_MINS);
-      now.add(Calendar.MILLISECOND, timeZoneOffsetInMinutes * 60000);
-    }
 
     if (args != null && args.containsKey(RNConstants.ARG_VALUE)) {
       set(args.getLong(RNConstants.ARG_VALUE));
+    }
+
+    if (args != null && args.containsKey(RNConstants.ARG_TZOFFSET_MINS)) {
+      now.setTimeZone(TimeZone.getTimeZone("GMT"));
+      Long timeZoneOffsetInMinutesFallback = args.getLong(RNConstants.ARG_TZOFFSET_MINS);
+      Integer timeZoneOffsetInMinutes = args.getInt(RNConstants.ARG_TZOFFSET_MINS, timeZoneOffsetInMinutesFallback.intValue());
+      now.add(Calendar.MILLISECOND, timeZoneOffsetInMinutes * 60000);
     }
   }
 

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -176,17 +176,14 @@ describe('Example', () => {
 
     if (isIOS()) {
       const testElement = getDateTimePickerIOS();
-      await testElement.setColumnToValue(0, '2');
-      await testElement.setColumnToValue(1, '44');
-      await testElement.setColumnToValue(2, 'PM');
-
-      await expect(timeText).toHaveText('13:44');
+      await testElement.setColumnToValue(0, '12');
+      await testElement.setColumnToValue(1, '30');
+      await testElement.setColumnToValue(2, 'AM');
     } else {
       await userChangesMinuteValue();
       await userTapsOkButtonAndroid();
-
-      await expect(timeText).toHaveText('23:30');
     }
+    await expect(timeText).toHaveText('23:30');
   });
 
   it(':android: given we specify neutralButtonLabel, tapping the corresponding button sets date to the beginning of the unix time epoch', async () => {

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -185,7 +185,7 @@ describe('Example', () => {
       await userChangesMinuteValue();
       await userTapsOkButtonAndroid();
 
-      await expect(timeText).toHaveText('22:30');
+      await expect(timeText).toHaveText('23:30');
     }
   });
 

--- a/src/datetimepicker.android.js
+++ b/src/datetimepicker.android.js
@@ -66,10 +66,7 @@ function getPicker({
 
 function timeZoneOffsetDateSetter(date, timeZoneOffsetInMinutes) {
   let localDate = date;
-  if (
-    typeof timeZoneOffsetInMinutes !== 'undefined' &&
-    timeZoneOffsetInMinutes >= 0
-  ) {
+  if (typeof timeZoneOffsetInMinutes === 'number') {
     const offset =
       localDate.getTimezoneOffset() * MIN_MS + timeZoneOffsetInMinutes * MIN_MS;
     localDate = new Date(date.getTime() - offset);


### PR DESCRIPTION
# Summary

I found out that the datetime picker uses the device timezone by default and if we use the prop `timezoneOffsetInMinutes` then it uses the utc time. Basically the prop `timezoneOffsetInMinutes` was not working. There was already a PR for this fix but it was failing e2e tests and the submitter was not responding since April 10 so I am making this PR in which I have fixed the issue and the e2e tests as well. The PR already made is mentioned below.

## Related Pull Requests

https://github.com/react-native-datetimepicker/datetimepicker/pull/431

## Test Plan

### Display initially passed date (input)

- (timezones: `device: GMT +3`, `app: GMT -7`)
- pass `2021-04-09T17:00:00.000Z` date (for UTC it stands for `17:00`, but for app timezone `-7` it should be treated like `10:00`)
- pass `timeZoneOffsetInMinutes={-420}` prop (`-420 = -7 * 60`)
- **Expected**: TimePicker should display `10:00` as initial selected date
- **Actual**: TimePicker displays `17:00` as initial selected date
According to this fact,  we can suppose that `timezoneOffsetInMinutes` prop is ignored and UTC hours & minutes are displayed instead.

### What's required for testing (prerequisites)?

- App uses fixed timezone for date handling/management (for example `GMT -7`)
- Device timezone should differ from app timezone (`device: GMT +3`, `app: GMT -7`)
- Android :slightly_smiling_face:

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅    |

## Checklist

- [x] I have tested this on a device and a simulator

