### PR TITLE
Import `HostComponent` instead of `NativeComponent` Type

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -4,7 +4,7 @@
  */
 
 import type {SyntheticEvent} from 'CoreEventTypes';
-import type {NativeComponent} from 'ReactNative';
+import type {HostComponent} from 'ReactNative';
 import type {ViewProps} from 'ViewPropTypes';
 import type {ElementRef} from 'react';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
@@ -183,7 +183,7 @@ export type DateTimePickerResult = $ReadOnly<{|
   minute: number,
 |}>;
 
-export type RCTDateTimePickerNative = Class<NativeComponent<IOSNativeProps>>;
+export type RCTDateTimePickerNative = Class<HostComponent<IOSNativeProps>>;
 export type NativeRef = {
   current: ElementRef<RCTDateTimePickerNative> | null,
 };


### PR DESCRIPTION
# Summary

Updates the import of `NativeComponent` from `ReactNative` to instead import `HostComponent`. This fixes Flow errors when used alongside the latest version of React Native.

https://github.com/facebook/react/pull/18036 removed the `NativeComponent` type.

## Test Plan

```
$ yarn
$ yarn test
$ flow
```