### PR TITLE
feat: remove locale prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ React Native date & time picker component for iOS, Android and Windows.
     - [`firstDayOfWeek` (`optional`, `Windows only`)](#firstDayOfWeek-optional-windows-only)
     - [`textColor` (`optional`, `iOS only`)](#textColor-optional-ios-only)
     - [`themeVariant` (`optional`, `iOS only`)](#themeVariant-optional-ios-only)
-    - [`locale` (`optional`, `iOS only`)](#locale-optional-ios-only)
     - [`is24Hour` (`optional`, `Windows and Android only`)](#is24hour-optional-windows-and-android-only)
     - [`neutralButtonLabel` (`optional`, `Android only`)](#neutralbuttonlabel-optional-android-only)
     - [`minuteInterval` (`optional`)](#minuteinterval-optional)
@@ -176,6 +175,14 @@ export const App = () => {
   );
 };
 ```
+
+## Locale note
+
+On Android, the picker will be controlled by the system locale. If you wish to change it, [see instructions here](https://stackoverflow.com/a/2900144/2070942).
+
+On iOS, the locale can be controlled from xCode, as [documented here](https://developer.apple.com/documentation/xcode/adding-support-for-languages-and-regions).
+
+For Expo, follow the [localization docs](https://docs.expo.dev/distribution/app-stores/#localizing-your-ios-app).
 
 ## Props
 
@@ -308,14 +315,6 @@ Allows changing of the textColor of the date picker. Has effect only when `displ
 
 ```js
 <RNDateTimePicker textColor="red" />
-```
-
-#### `locale` (`optional`, `iOS only`)
-
-Allows changing of the locale of the component. By default it uses the device's locale.
-
-```js
-<RNDateTimePicker locale="es-ES" />
 ```
 
 #### `is24Hour` (`optional`, `Windows and Android only`)

--- a/ios/RNDateTimePickerManager.m
+++ b/ios/RNDateTimePickerManager.m
@@ -97,7 +97,6 @@ RCT_EXPORT_METHOD(getDefaultDisplayValue:(NSDictionary *)options resolver:(RCTPr
 }
 
 RCT_EXPORT_VIEW_PROPERTY(date, NSDate)
-RCT_EXPORT_VIEW_PROPERTY(locale, NSLocale)
 RCT_EXPORT_VIEW_PROPERTY(minimumDate, NSDate)
 RCT_EXPORT_VIEW_PROPERTY(maximumDate, NSDate)
 RCT_EXPORT_VIEW_PROPERTY(minuteInterval, NSInteger)

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -43,7 +43,6 @@ const getDisplaySafe = (display: IOSDisplay): IOSDisplay => {
 
 export default function Picker({
   value,
-  locale,
   maximumDate,
   minimumDate,
   style,
@@ -116,7 +115,6 @@ export default function Picker({
       ref={_picker}
       style={StyleSheet.compose(heightStyle, style)}
       date={dates.value}
-      locale={locale !== null && locale !== '' ? locale : undefined}
       maximumDate={dates.maximumDate}
       minimumDate={dates.minimumDate}
       mode={mode}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -68,11 +68,6 @@ export type IOSNativeProps = Readonly<
     date?: Date;
 
     /**
-     * The date picker locale.
-     */
-    locale?: string;
-
-    /**
      * The interval at which minutes can be selected.
      */
     minuteInterval?: MinuteInterval;

--- a/src/types.js
+++ b/src/types.js
@@ -89,11 +89,6 @@ export type IOSNativeProps = $ReadOnly<{|
   date?: ?Date,
 
   /**
-   * The date picker locale.
-   */
-  locale?: ?string,
-
-  /**
    * The interval at which minutes can be selected.
    */
   minuteInterval?: MinuteInterval,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

The module allowed overriding locale on ios, but doing so does not really work in newer ios versions. Supporting locales in your app should be done the "proper way" as seen here https://developer.apple.com/documentation/xcode/adding-support-for-languages-and-regions

this is also documented in readme

closes #522, #82, #233, #272, #300, #330, #388, #429, #439


## Test Plan

tested locally

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
