### PR TITLE
iOS `locale` Prop ignores day of the week (Sun, Mon, Tues... Sat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,6 @@ export const App = () => {
 On Android, the picker will be controlled by the system locale. If you wish to change it, [see instructions here](https://stackoverflow.com/a/2900144/2070942).
 
 On iOS, the locale can be controlled from Xcode, as [documented here](https://developer.apple.com/documentation/xcode/adding-support-for-languages-and-regions). 
-> To localize the calendar days (avoid mixed language for month and day names): If you use a library like [i18next](https://github.com/i18next/react-i18next) or [react-localize-redux](https://github.com/ryandrewjohnson/react-localize-redux) to manage your translations, it is sufficient to add your target languages in the `project.pbxproj` as described in the Apple Documentation - but you are not required to add any localization keys (like the days of the week). iOS will automatically display the correct localized strings as long as the target language is contained in `project.pbxproj`.
-
-There is also the iOS-only locale prop that can be used to force locale in some cases but its usage is discouraged due to [not working robustly in all picker modes](./docs/images/ios_date_new.png) (note the mixed month and day names).
 
 For Expo, follow the [localization docs](https://docs.expo.dev/distribution/app-stores/#localizing-your-ios-app).
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ export const App = () => {
 
 On Android, the picker will be controlled by the system locale. If you wish to change it, [see instructions here](https://stackoverflow.com/a/2900144/2070942).
 
-On iOS, the locale can be controlled from Xcode, as [documented here](https://developer.apple.com/documentation/xcode/adding-support-for-languages-and-regions). 
+On iOS, the locale can be controlled from Xcode, as [documented here](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/TestingYourInternationalApp/TestingYourInternationalApp.html#//apple_ref/doc/uid/10000171i-CH7-SW2). 
 
 For Expo, follow the [localization docs](https://docs.expo.dev/distribution/app-stores/#localizing-your-ios-app).
 

--- a/ios/RNDateTimePickerManager.m
+++ b/ios/RNDateTimePickerManager.m
@@ -97,7 +97,9 @@ RCT_EXPORT_METHOD(getDefaultDisplayValue:(NSDictionary *)options resolver:(RCTPr
 }
 
 RCT_EXPORT_VIEW_PROPERTY(date, NSDate)
-RCT_EXPORT_VIEW_PROPERTY(locale, NSLocale)
+RCT_CUSTOM_VIEW_PROPERTY(locale, NSLocale, RNDateTimePicker) {
+    [view setValue:[RCTConvert NSLocale:json] forKey:@"locale"];
+}
 RCT_EXPORT_VIEW_PROPERTY(minimumDate, NSDate)
 RCT_EXPORT_VIEW_PROPERTY(maximumDate, NSDate)
 RCT_EXPORT_VIEW_PROPERTY(minuteInterval, NSInteger)


### PR DESCRIPTION
Closes Issue #569

# Summary

Fixes flakey iOS only locale prop

## Test Plan

Please check Issue #569

### What's required for testing (prerequisites)?

Please check Issue #569

### What are the steps to reproduce (after prerequisites)?

Please check Issue #569

## Compatibility


| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| Android |    ❌     |

## Checklist

- [x] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
