### PR TITLE
fix: remove wrong postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "start:windows": "react-native start --use-react-native-windows",
     "test": "jest ./test",
     "posttest": "npm run lint",
-    "postinstall": "patch-package",
     "lint": "eslint {example,src,test}/**/*.js src/index.d.ts",
     "flow": "flow check",
     "detox:ios:build:debug": "detox build -c ios.sim.debug",


### PR DESCRIPTION
postinstall is meant only for the example, not the package itself