### PR TITLE
Add accentColor props for iOS datetimepicker (#20)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
             nvm install v15.11.0
             nvm alias default v15.11.0
             echo 'export PATH=/opt/circleci/.nvm/versions/node/v15.11.0/bin:$PATH' >> $BASH_ENV
+            avdmanager list device
       - android/create-avd:
           avd-name: TestingAVD
           system-image: system-images;android-29;default;x86

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - android/create-avd:
           avd-name: TestingAVD
           system-image: system-images;android-29;default;x86
-          additional-args: --device "Pixel 4 XL"
+          additional-args: --device "pixel_4_xl"
           install: true
       - android/start-emulator:
           avd-name: TestingAVD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,11 +73,10 @@ jobs:
             nvm install v15.11.0
             nvm alias default v15.11.0
             echo 'export PATH=/opt/circleci/.nvm/versions/node/v15.11.0/bin:$PATH' >> $BASH_ENV
-            avdmanager list device
       - android/create-avd:
           avd-name: TestingAVD
           system-image: system-images;android-29;default;x86
-          additional-args: --device "Pixel 5"
+          additional-args: --device "Pixel 4 XL"
           install: true
       - android/start-emulator:
           avd-name: TestingAVD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
       - android/create-avd:
           avd-name: TestingAVD
           system-image: system-images;android-29;default;x86
+          additional-args: --device "Pixel 5"
           install: true
       - android/start-emulator:
           avd-name: TestingAVD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ For cleaning all the detox builds just run `npm run detox:clean`.
   ```sh
   # Debug requires to run Metro Bundler
   yarn start
-  cd "example/ios" && npx pod-install && cd "../.."
+  cd "example/ios" && npx pod-install && cd -
   yarn detox:ios:build:debug
   yarn detox:ios:test:debug
   ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ For cleaning all the detox builds just run `npm run detox:clean`.
   ```sh
   # Debug requires to run Metro Bundler
   yarn start
+  cd "example/ios" && npx pod-install && cd "../.."
   yarn detox:ios:build:debug
   yarn detox:ios:test:debug
   ```

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Allows changing of the textColor of the date picker. Has effect only when `displ
 #### `accentColor` (`optional`, `iOs only`)
 
 Allows changing the accentColor (tintColor) of the date picker.
-Has not effect when `display` is `"spinner"`.
+Has no effect when `display` is `"spinner"`.
 
 #### `themeVariant` (`optional`, `iOS only`)
 

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Allows changing of the textColor of the date picker. Has effect only when `displ
 <RNDateTimePicker textColor="red" />
 ```
 
-#### `accentColor` (`optional`, `iOs only`)
+#### `accentColor` (`optional`, `iOS only`)
 
 Allows changing the accentColor (tintColor) of the date picker.
 Has no effect when `display` is `"spinner"`.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ React Native date & time picker component for iOS, Android and Windows.
     - [`dateFormat` (`optional`, `Windows only`)](#dateFormat-optional-windows-only)
     - [`firstDayOfWeek` (`optional`, `Windows only`)](#firstDayOfWeek-optional-windows-only)
     - [`textColor` (`optional`, `iOS only`)](#textColor-optional-ios-only)
+    - [`accentColor` (`optional`, `iOS only`)](#accentColor-optional-ios-only)
     - [`themeVariant` (`optional`, `iOS only`)](#themevariant-optional-ios-only)
     - [`locale` (`optional`, `iOS only`)](#locale-optional-ios-only)
     - [`is24Hour` (`optional`, `Windows and Android only`)](#is24hour-optional-windows-and-android-only)
@@ -386,6 +387,11 @@ Allows changing of the textColor of the date picker. Has effect only when `displ
 ```js
 <RNDateTimePicker textColor="red" />
 ```
+
+#### `accentColor` (`optional`, `iOs only`)
+
+Allows changing the accentColor (tintColor) of the date picker.
+Has not effect when `display` is `"spinner"`.
 
 #### `themeVariant` (`optional`, `iOS only`)
 

--- a/example/App.js
+++ b/example/App.js
@@ -68,7 +68,8 @@ export const App = () => {
   const [tzOffsetInMinutes, setTzOffsetInMinutes] = useState(undefined);
   const [mode, setMode] = useState(MODE_VALUES[0]);
   const [show, setShow] = useState(false);
-  const [color, setColor] = useState();
+  const [textColor, setTextColor] = useState();
+  const [accentColor, setAccentColor] = useState();
   const [display, setDisplay] = useState(DISPLAY_VALUES[0]);
   const [interval, setMinInterval] = useState(1);
   const [neutralButtonLabel, setNeutralButtonLabel] = useState(undefined);
@@ -187,12 +188,25 @@ export const App = () => {
                 text color (iOS only)
               </ThemedText>
               <ThemedTextInput
-                value={color}
+                value={textColor}
                 style={{height: 60, flex: 1}}
                 onChangeText={(text) => {
-                  setColor(text.toLowerCase());
+                  setTextColor(text.toLowerCase());
                 }}
-                placeholder="color"
+                placeholder="textColor"
+              />
+            </View>
+            <View style={styles.header}>
+              <ThemedText style={{margin: 10, flex: 1}}>
+                accent color (iOS only)
+              </ThemedText>
+              <ThemedTextInput
+                value={accentColor}
+                style={{height: 60, flex: 1}}
+                onChangeText={(text) => {
+                  setAccentColor(text.toLowerCase());
+                }}
+                placeholder="accentColor"
               />
             </View>
             <View style={styles.header}>
@@ -294,22 +308,25 @@ export const App = () => {
               />
             </View>
             {show && (
-              <DateTimePicker
-                testID="dateTimePicker"
-                timeZoneOffsetInMinutes={tzOffsetInMinutes}
-                minuteInterval={interval}
-                maximumDate={maximumDate}
-                minimumDate={minimumDate}
-                value={date}
-                mode={mode}
-                is24Hour
-                display={display}
-                onChange={onChange}
-                style={styles.iOsPicker}
-                textColor={color || undefined}
-                neutralButtonLabel={neutralButtonLabel}
-                disabled={disabled}
-              />
+              <View>
+                <DateTimePicker
+                  testID="dateTimePicker"
+                  timeZoneOffsetInMinutes={tzOffsetInMinutes}
+                  minuteInterval={interval}
+                  maximumDate={maximumDate}
+                  minimumDate={minimumDate}
+                  value={date}
+                  mode={mode}
+                  is24Hour
+                  display={display}
+                  onChange={onChange}
+                  style={styles.iOsPicker}
+                  textColor={textColor || undefined}
+                  accentColor={accentColor || undefined}
+                  neutralButtonLabel={neutralButtonLabel}
+                  disabled={disabled}
+                />
+              </View>
             )}
           </View>
         </ScrollView>

--- a/example/App.js
+++ b/example/App.js
@@ -43,7 +43,7 @@ const ThemedTextInput = (props) => {
 
   const TextElement = React.createElement(TextInput, props);
   return React.cloneElement(TextElement, {
-    style: [props.style, textColorByMode],
+    style: [props.style, styles.textInput, textColorByMode],
     placeholderTextColor: isDarkMode ? Colors.white : Colors.black,
   });
 };
@@ -191,12 +191,11 @@ export const App = () => {
               }}
             />
             <View style={styles.header}>
-              <ThemedText style={{margin: 10, flex: 1}}>
+              <ThemedText style={styles.textLabel}>
                 text color (iOS only)
               </ThemedText>
               <ThemedTextInput
                 value={textColor}
-                style={{height: 60, flex: 1}}
                 onChangeText={(text) => {
                   setTextColor(text.toLowerCase());
                 }}
@@ -204,12 +203,11 @@ export const App = () => {
               />
             </View>
             <View style={styles.header}>
-              <ThemedText style={{margin: 10, flex: 1}}>
+              <ThemedText style={styles.textLabel}>
                 accent color (iOS only)
               </ThemedText>
               <ThemedTextInput
                 value={accentColor}
-                style={{height: 60, flex: 1}}
                 onChangeText={(text) => {
                   setAccentColor(text.toLowerCase());
                 }}
@@ -217,25 +215,24 @@ export const App = () => {
               />
             </View>
             <View style={styles.header}>
-              <ThemedText style={{margin: 10, flex: 1}}>
+              <ThemedText style={styles.textLabel}>
                 disabled (iOS only)
               </ThemedText>
               <Switch value={disabled} onValueChange={setDisabled} />
             </View>
             <View style={styles.header}>
-              <ThemedText style={{margin: 10, flex: 1}}>
+              <ThemedText style={styles.textLabel}>
                 neutralButtonLabel (android only)
               </ThemedText>
               <ThemedTextInput
                 value={neutralButtonLabel}
-                style={{height: 60, flex: 1}}
                 onChangeText={setNeutralButtonLabel}
                 placeholder="neutralButtonLabel"
                 testID="neutralButtonLabelTextInput"
               />
             </View>
             <View style={styles.header}>
-              <ThemedText style={{margin: 10, flex: 1}}>
+              <ThemedText style={styles.textLabel}>
                 [android] show and dismiss picker after 3 secs
               </ThemedText>
             </View>
@@ -525,6 +522,14 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     flexDirection: 'row',
+  },
+  textLabel: {
+    margin: 10,
+    flex: 1,
+  },
+  textInput: {
+    height: 60,
+    flex: 1,
   },
   button: {
     alignItems: 'center',

--- a/example/App.js
+++ b/example/App.js
@@ -312,25 +312,23 @@ export const App = () => {
               />
             </View>
             {show && (
-              <View>
-                <DateTimePicker
-                  testID="dateTimePicker"
-                  timeZoneOffsetInMinutes={tzOffsetInMinutes}
-                  minuteInterval={interval}
-                  maximumDate={maximumDate}
-                  minimumDate={minimumDate}
-                  value={date}
-                  mode={mode}
-                  is24Hour
-                  display={display}
-                  onChange={onChange}
-                  style={styles.iOsPicker}
-                  textColor={textColor || undefined}
-                  accentColor={accentColor || undefined}
-                  neutralButtonLabel={neutralButtonLabel}
-                  disabled={disabled}
-                />
-              </View>
+              <DateTimePicker
+                testID="dateTimePicker"
+                timeZoneOffsetInMinutes={tzOffsetInMinutes}
+                minuteInterval={interval}
+                maximumDate={maximumDate}
+                minimumDate={minimumDate}
+                value={date}
+                mode={mode}
+                is24Hour
+                display={display}
+                onChange={onChange}
+                style={styles.iOsPicker}
+                textColor={textColor || undefined}
+                accentColor={accentColor || undefined}
+                neutralButtonLabel={neutralButtonLabel}
+                disabled={disabled}
+              />
             )}
           </View>
         </ScrollView>

--- a/example/App.js
+++ b/example/App.js
@@ -14,7 +14,7 @@ import {
 import DateTimePicker from '@react-native-community/datetimepicker';
 import SegmentedControl from '@react-native-segmented-control/segmented-control';
 import {Colors} from 'react-native/Libraries/NewAppScreen';
-import React, {useState} from 'react';
+import React, {useRef, useState} from 'react';
 import {Picker} from 'react-native-windows';
 import moment from 'moment';
 import {
@@ -88,6 +88,8 @@ export const App = () => {
     '{dayofweek.abbreviated(2)}',
   );
 
+  const scrollRef = useRef(null);
+
   const handleResetPress = () => {
     setDate(undefined);
   };
@@ -132,7 +134,12 @@ export const App = () => {
     return (
       <SafeAreaView style={[backgroundStyle, {flex: 1}]}>
         <StatusBar barStyle="dark-content" />
-        <ScrollView testID="DateTimePickerScrollView">
+        <ScrollView
+          testID="DateTimePickerScrollView"
+          ref={scrollRef}
+          onContentSizeChange={() =>
+            scrollRef.current?.scrollToEnd({animated: true})
+          }>
           {global.HermesInternal != null && (
             <View style={styles.engine}>
               <Text testID="hermesIndicator" style={styles.footer}>

--- a/example/App.js
+++ b/example/App.js
@@ -137,9 +137,11 @@ export const App = () => {
         <ScrollView
           testID="DateTimePickerScrollView"
           ref={scrollRef}
-          onContentSizeChange={() =>
-            scrollRef.current?.scrollToEnd({animated: true})
-          }>
+          onContentSizeChange={() => {
+            if (Platform.OS === 'ios') {
+              scrollRef.current?.scrollToEnd({animated: true});
+            }
+          }}>
           {global.HermesInternal != null && (
             <View style={styles.engine}>
               <Text testID="hermesIndicator" style={styles.footer}>

--- a/example/e2e/utils/matchers.js
+++ b/example/e2e/utils/matchers.js
@@ -6,7 +6,7 @@ const elementByText = (text) => element(by.text(text));
 const getDateTimePickerIOS = () =>
   element(by.type('UIPickerView').withAncestor(by.id('dateTimePicker')));
 
-const getInlineTimePickerIOS = () => element(by.type('RNDateTimePicker'));
+const getInlineTimePickerIOS = () => element(by.label('Time Picker'));
 
 const getDateTimePickerControlIOS = () => element(by.type('UIDatePicker'));
 

--- a/example/e2e/utils/matchers.js
+++ b/example/e2e/utils/matchers.js
@@ -6,7 +6,7 @@ const elementByText = (text) => element(by.text(text));
 const getDateTimePickerIOS = () =>
   element(by.type('UIPickerView').withAncestor(by.id('dateTimePicker')));
 
-const getInlineTimePickerIOS = () => element(by.label('Time Picker'));
+const getInlineTimePickerIOS = () => element(by.type('RNDateTimePicker'));
 
 const getDateTimePickerControlIOS = () => element(by.type('UIDatePicker'));
 

--- a/ios/RNDateTimePickerManager.m
+++ b/ios/RNDateTimePickerManager.m
@@ -141,6 +141,19 @@ RCT_CUSTOM_VIEW_PROPERTY(textColor, UIColor, RNDateTimePicker)
   }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(accentColor, UIColor, RNDateTimePicker)
+{
+    if (json) {
+        [view setTintColor:[RCTConvert UIColor:json]];
+    } else {
+        if (@available(iOS 15.0, *)) {
+            [view setTintColor:[UIColor tintColor]];
+        } else {
+            [view setTintColor:[UIColor systemBlueColor]];
+        }
+    }
+}
+
 // TODO vonovak setting preferredDatePickerStyle invalidates minuteinterval
 RCT_CUSTOM_VIEW_PROPERTY(displayIOS, RNCUIDatePickerStyle, RNDateTimePicker)
 {

--- a/package.json
+++ b/package.json
@@ -114,11 +114,11 @@
         "build": "export RCT_NO_LAUNCH_PACKAGER=true && (cd example/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug)",
         "type": "android.emulator",
         "device": {
-          "avdName": "Pixel_4_Android_12_api_31"
+          "avdName": "Pixel_5_Android_12_api_31"
         }
       },
       "android.device.debug": {
-        "binaryPath": "example/android/app/build/outputs/apk/debug/app-debug.apk",
+        "binaryPath": "build/outputs/apk/androidTest/debug/datetimepicker-debug-androidTest.apk",
         "build": "export RCT_NO_LAUNCH_PACKAGER=true && (cd example/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug)",
         "type": "android.attached",
         "device": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         }
       },
       "android.device.debug": {
-        "binaryPath": "build/outputs/apk/androidTest/debug/datetimepicker-debug-androidTest.apk",
+        "binaryPath": "example/android/app/build/outputs/apk/debug/app-debug.apk",```
         "build": "export RCT_NO_LAUNCH_PACKAGER=true && (cd example/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug)",
         "type": "android.attached",
         "device": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
         }
       },
       "android.device.debug": {
-        "binaryPath": "example/android/app/build/outputs/apk/debug/app-debug.apk",```
+        "binaryPath": "example/android/app/build/outputs/apk/debug/app-debug.apk",
         "build": "export RCT_NO_LAUNCH_PACKAGER=true && (cd example/android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug)",
         "type": "android.attached",
         "device": {

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -52,7 +52,7 @@ export default function Picker({
   minuteInterval,
   timeZoneOffsetInMinutes,
   textColor,
-  tintColor,
+  accentColor,
   themeVariant,
   onChange,
   mode = ANDROID_MODE.date,
@@ -127,7 +127,7 @@ export default function Picker({
       timeZoneOffsetInMinutes={timeZoneOffsetInMinutes}
       onChange={_onChange}
       textColor={textColor}
-      tintColor={tintColor}
+      accentColor={accentColor}
       themeVariant={themeVariant}
       onStartShouldSetResponder={() => true}
       onResponderTerminationRequest={() => false}

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -52,6 +52,7 @@ export default function Picker({
   minuteInterval,
   timeZoneOffsetInMinutes,
   textColor,
+  tintColor,
   themeVariant,
   onChange,
   mode = ANDROID_MODE.date,
@@ -126,6 +127,7 @@ export default function Picker({
       timeZoneOffsetInMinutes={timeZoneOffsetInMinutes}
       onChange={_onChange}
       textColor={textColor}
+      tintColor={tintColor}
       themeVariant={themeVariant}
       onStartShouldSetResponder={() => true}
       onResponderTerminationRequest={() => false}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -99,6 +99,14 @@ export type IOSNativeProps = Readonly<
     textColor?: string;
 
     /**
+     * The date picker accent color.
+     *
+     * Sets the color of the selected, date and navigation icons.
+     * Has no effect for display 'spinner'.
+     */
+    accentColor?: string;
+
+    /**
      * Override theme variant used by iOS native picker
      */
     themeVariant?: 'dark' | 'light';

--- a/src/types.js
+++ b/src/types.js
@@ -120,6 +120,14 @@ export type IOSNativeProps = $ReadOnly<{|
   textColor?: ?ColorValue,
 
   /**
+   * The date picker accent color.
+   *
+   * Sets the color of the selected, date and navigation icons.
+   * Has no effect for display 'spinner'.
+   */
+  accentColor?: ?ColorValue,
+
+  /**
    * Override theme variant used by iOS native picker
    */
   themeVariant?: 'dark' | 'light',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This adds prop accentColor for iOS.
This relates to #20.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

Testing can be done with the example app. I added another input (accentColor) which can be used for testing.

### What are the steps to reproduce (after prerequisites)?

Select display to compact or inline.
Enter a color value (i.e. `#f00`) into the `accentColor` field.
Check if picker appearance changes.

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable

e2e test can not check color changes.
