### PR TITLE
chore: remove hardcoded timezone in e2e tests

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -96,8 +96,9 @@ export const App = () => {
 
   const onChange = (event, selectedDate) => {
     const currentDate = selectedDate || date;
-
-    setShow(Platform.OS === 'ios');
+    if (Platform.OS === 'android') {
+      setShow(false);
+    }
     if (event.type === 'neutralButtonPressed') {
       setDate(new Date(0));
     } else {
@@ -159,11 +160,15 @@ export const App = () => {
                 Example DateTime Picker
               </ThemedText>
             </View>
-            <ThemedText selectable testID="timeInfo">
-              TZ: {RNLocalize.getTimeZone()}, TZOffset:{' '}
-              {new Date().getTimezoneOffset() / 60} original:{' '}
-              {moment(sourceDate).format('MM/DD/YYYY HH:mm')}
-            </ThemedText>
+            <View style={{flexDirection: 'row'}}>
+              <ThemedText selectable testID="timeInfo">
+                TZ: {RNLocalize.getTimeZone()}, original:{' '}
+                {moment(sourceDate).format('MM/DD/YYYY HH:mm')}
+              </ThemedText>
+              <ThemedText>
+                , TZOffset:{new Date().getTimezoneOffset() / 60}
+              </ThemedText>
+            </View>
             <ThemedText>mode prop:</ThemedText>
             <SegmentedControl
               values={MODE_VALUES}

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -37,7 +37,7 @@ describe('e2e tests', () => {
 
   it('timeInfo heading has expected content', async () => {
     await expect(elementById('timeInfo')).toHaveText(
-      'TZ: Europe/Prague, TZOffset: -1 original: 11/13/2021 11:00',
+      'TZ: Europe/Prague, original: 11/13/2021 11:00',
     );
   });
 
@@ -178,14 +178,14 @@ describe('e2e tests', () => {
 
       if (isIOS()) {
         const testElement = getDateTimePickerIOS();
-        await testElement.setColumnToValue(0, '10');
+        await testElement.setColumnToValue(0, '7');
         await testElement.setColumnToValue(1, '30');
         await testElement.setColumnToValue(2, 'AM');
       } else {
-        await userChangesTimeValue({hours: '10', minutes: '30'});
+        await userChangesTimeValue({hours: '7', minutes: '30'});
         await userTapsOkButtonAndroid();
       }
-      await expect(getTimeText()).toHaveText('09:30');
+      await expect(getTimeText()).toHaveText('06:30');
     });
 
     it('should let you pick tomorrow but not yesterday when setting min/max', async () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

motivation is to make e2e tests pass

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
