### PR TITLE
hide calendar view on Android tablets when the spinner mode is selected

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDismissableDatePickerDialog.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDismissableDatePickerDialog.java
@@ -106,5 +106,9 @@ public class RNDismissableDatePickerDialog extends DatePickerDialog {
         throw new RuntimeException(e);
       }
     }
+    if (display == RNDatePickerDisplay.SPINNER){
+      if(this.getDatePicker() != null)
+        this.getDatePicker().setCalendarViewShown(false);
+    }
   }
 }


### PR DESCRIPTION
# Summary

fix https://github.com/react-native-datetimepicker/datetimepicker/issues/481

## Test Plan
this PR will hide the calendar view when spinner mode is selected

<img width="386" alt="163716614-578b7f2a-3d98-46f1-bbee-ff412abb4c84" src="https://user-images.githubusercontent.com/2734096/163994906-7d54c75c-f8b9-45a1-ab78-3f730ca336d3.png">
![Uploading 2 (1).jpg…]()


### What are the steps to reproduce (after prerequisites)?

## Compatibility
only Android is affected, by merging this the spinner date picker on tablets will have the same looks as phones (without calendar view)

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
