### PR TITLE
Fix Break in Windows JS following #574

### DIFF
--- a/src/picker.windows.js
+++ b/src/picker.windows.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+ import {requireNativeComponent} from 'react-native';
+ 
+ export default ((requireNativeComponent(
+    'RNDateTimePickerWindows',
+    // $FlowFixMe Flow: Unclear type. Using `any`, `Object`, or `Function` types is not safe!
+  )));

--- a/src/picker.windows.js
+++ b/src/picker.windows.js
@@ -9,7 +9,7 @@
  */
 import {requireNativeComponent} from 'react-native';
 
-export default ((requireNativeComponent(
+export default requireNativeComponent(
   'RNDateTimePickerWindows',
   // $FlowFixMe Flow: Unclear type. Using `any`, `Object`, or `Function` types is not safe!
-)));
+);

--- a/src/picker.windows.js
+++ b/src/picker.windows.js
@@ -9,7 +9,7 @@
  */
 import {requireNativeComponent} from 'react-native';
 
-export default requireNativeComponent(
+export default (requireNativeComponent(
   'RNDateTimePickerWindows',
   // $FlowFixMe Flow: Unclear type. Using `any`, `Object`, or `Function` types is not safe!
-);
+): any);

--- a/src/picker.windows.js
+++ b/src/picker.windows.js
@@ -7,9 +7,9 @@
  * @format
  * @flow strict-local
  */
- import {requireNativeComponent} from 'react-native';
- 
- export default ((requireNativeComponent(
-    'RNDateTimePickerWindows',
-    // $FlowFixMe Flow: Unclear type. Using `any`, `Object`, or `Function` types is not safe!
-  )));
+import {requireNativeComponent} from 'react-native';
+
+export default ((requireNativeComponent(
+  'RNDateTimePickerWindows',
+  // $FlowFixMe Flow: Unclear type. Using `any`, `Object`, or `Function` types is not safe!
+)));


### PR DESCRIPTION

# Summary

Changes in #574 break Windows JS because no picker.windows.js file exists.

## Test Plan

Tested via React Native Windows app React Native Gallery.

## Compatibility

| Windows |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
