### PR TITLE
Android: add custom label for positive and negative button 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ React Native date & time picker component for iOS, Android and Windows.
     - [`themeVariant` (`optional`, `iOS only`)](#themevariant-optional-ios-only)
     - [`locale` (`optional`, `iOS only`)](#locale-optional-ios-only)
     - [`is24Hour` (`optional`, `Windows and Android only`)](#is24hour-optional-windows-and-android-only)
+    - [`positiveButtonLabel` (`optional`, `Android only`)](#positiveButtonLabel-optional-android-only)
+    - [`negativeButtonLabel` (`optional`, `Android only`)](#negativeButtonLabel-optional-android-only)
     - [`neutralButtonLabel` (`optional`, `Android only`)](#neutralbuttonlabel-optional-android-only)
     - [`minuteInterval` (`optional`)](#minuteinterval-optional)
     - [`style` (`optional`, `iOS only`)](#style-optional-ios-only)
@@ -425,6 +427,22 @@ Allows changing of the time picker to a 24 hour format. By default, this value i
 
 ```js
 <RNDateTimePicker is24Hour={true} />
+```
+
+#### `positiveButtonLabel` (`optional`, `Android only`)
+
+Changes the label of the positive button.
+
+```js
+<RNDateTimePicker positiveButtonLabel="OK!" />
+```
+
+#### `negativeButtonLabel` (`optional`, `Android only`)
+
+Changes the label of the negative button.
+
+```js
+<RNDateTimePicker positiveButtonLabel="Negative" />
 ```
 
 #### `neutralButtonLabel` (`optional`, `Android only`)

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNConstants.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNConstants.java
@@ -9,6 +9,8 @@ public final class RNConstants {
   public static final String ARG_IS24HOUR = "is24Hour";
   public static final String ARG_DISPLAY = "display";
   public static final String ARG_NEUTRAL_BUTTON_LABEL = "neutralButtonLabel";
+  public static final String ARG_POSITIVE_BUTTON_LABEL = "positiveButtonLabel";
+  public static final String ARG_NEGATIVE_BUTTON_LABEL = "negativeButtonLabel";
   public static final String ARG_TZOFFSET_MINS = "timeZoneOffsetInMinutes";
   public static final String ACTION_DATE_SET = "dateSetAction";
   public static final String ACTION_TIME_SET = "timeSetAction";

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
@@ -106,6 +106,12 @@ public class RNDatePickerDialogFragment extends DialogFragment {
     if (args != null && args.containsKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
       dialog.setButton(DialogInterface.BUTTON_NEUTRAL, args.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL), mOnNeutralButtonActionListener);
     }
+    if (args != null && args.containsKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
+      dialog.setButton(DialogInterface.BUTTON_POSITIVE, args.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL), dialog);
+    }
+    if (args != null && args.containsKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
+      dialog.setButton(DialogInterface.BUTTON_NEGATIVE, args.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL), dialog);
+    }
 
     final DatePicker datePicker = dialog.getDatePicker();
 

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
@@ -171,6 +171,12 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
     if (options.hasKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
       args.putString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL, options.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL));
     }
+    if (options.hasKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
+      args.putString(RNConstants.ARG_POSITIVE_BUTTON_LABEL, options.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL));
+    }
+    if (options.hasKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
+      args.putString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL, options.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL));
+    }
     if (options.hasKey(RNConstants.ARG_TZOFFSET_MINS) && !options.isNull(RNConstants.ARG_TZOFFSET_MINS)) {
       args.putLong(RNConstants.ARG_TZOFFSET_MINS, (long) options.getDouble(RNConstants.ARG_TZOFFSET_MINS));
     }

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
@@ -106,6 +106,12 @@ public class RNTimePickerDialogFragment extends DialogFragment {
     if (args != null && args.containsKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
       dialog.setButton(DialogInterface.BUTTON_NEUTRAL, args.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL), mOnNeutralButtonActionListener);
     }
+    if (args != null && args.containsKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
+      dialog.setButton(DialogInterface.BUTTON_POSITIVE, args.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL), dialog);
+    }
+    if (args != null && args.containsKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
+      dialog.setButton(DialogInterface.BUTTON_NEGATIVE, args.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL), dialog);
+    }
     return dialog;
   }
 

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
@@ -145,6 +145,12 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
     if (options.hasKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
       args.putString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL, options.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL));
     }
+    if (options.hasKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
+      args.putString(RNConstants.ARG_POSITIVE_BUTTON_LABEL, options.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL));
+    }
+    if (options.hasKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
+      args.putString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL, options.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL));
+    }
     if (options.hasKey(RNConstants.ARG_INTERVAL) && !options.isNull(RNConstants.ARG_INTERVAL)) {
       args.putInt(RNConstants.ARG_INTERVAL, options.getInt(RNConstants.ARG_INTERVAL));
     }

--- a/src/DateTimePickerAndroid.android.js
+++ b/src/DateTimePickerAndroid.android.js
@@ -30,7 +30,9 @@ function open(props: AndroidNativeProps) {
     is24Hour,
     minimumDate,
     maximumDate,
+    positiveButtonLabel,
     neutralButtonLabel,
+    negativeButtonLabel,
     minuteInterval,
     timeZoneOffsetInMinutes,
     onChange,
@@ -47,9 +49,11 @@ function open(props: AndroidNativeProps) {
     is24Hour,
     minimumDate,
     maximumDate,
-    neutralButtonLabel,
     minuteInterval,
     timeZoneOffsetInMinutes,
+    positiveButtonLabel,
+    neutralButtonLabel,
+    negativeButtonLabel,
   });
 
   const presentPicker = async () => {

--- a/src/androidUtils.js
+++ b/src/androidUtils.js
@@ -21,6 +21,8 @@ type Params = {
   neutralButtonLabel: AndroidNativeProps['neutralButtonLabel'],
   minuteInterval: AndroidNativeProps['minuteInterval'],
   timeZoneOffsetInMinutes: AndroidNativeProps['timeZoneOffsetInMinutes'],
+  positiveButtonLabel: AndroidNativeProps['positiveButtonLabel'],
+  negativeButtonLabel: AndroidNativeProps['negativeButtonLabel'],
 };
 export function getOpenPicker({
   mode,
@@ -32,6 +34,8 @@ export function getOpenPicker({
   neutralButtonLabel,
   minuteInterval,
   timeZoneOffsetInMinutes,
+  positiveButtonLabel,
+  negativeButtonLabel,
 }: Params): PresentPickerCallback {
   switch (mode) {
     case ANDROID_MODE.time:
@@ -44,6 +48,8 @@ export function getOpenPicker({
           is24Hour,
           neutralButtonLabel,
           timeZoneOffsetInMinutes,
+          positiveButtonLabel,
+          negativeButtonLabel,
         });
     default:
       return () =>
@@ -55,6 +61,8 @@ export function getOpenPicker({
           maximumDate,
           neutralButtonLabel,
           timeZoneOffsetInMinutes,
+          positiveButtonLabel,
+          negativeButtonLabel,
         });
   }
 }

--- a/src/datetimepicker.android.js
+++ b/src/datetimepicker.android.js
@@ -23,6 +23,8 @@ export default function RNDateTimePicker(props: AndroidNativeProps): null {
     neutralButtonLabel,
     minuteInterval,
     timeZoneOffsetInMinutes,
+    positiveButtonLabel,
+    negativeButtonLabel,
     onError,
   } = props;
   invariant(value, 'A date or time must be specified as `value` prop.');
@@ -46,6 +48,8 @@ export default function RNDateTimePicker(props: AndroidNativeProps): null {
         neutralButtonLabel,
         minuteInterval,
         timeZoneOffsetInMinutes,
+        positiveButtonLabel,
+        negativeButtonLabel,
         onError,
         onChange,
       };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -145,8 +145,6 @@ export type AndroidNativeProps = Readonly<
       positiveButtonLabel?: string;
       neutralButtonLabel?: string;
       negativeButtonLabel?: string;
-
-
       /**
        * callback when an error occurs inside the date picker native code (such as null activity)
        */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -142,7 +142,10 @@ export type AndroidNativeProps = Readonly<
        */
       minuteInterval?: MinuteInterval;
 
+      positiveButtonLabel?: string;
       neutralButtonLabel?: string;
+      negativeButtonLabel?: string;
+
 
       /**
        * callback when an error occurs inside the date picker native code (such as null activity)

--- a/src/types.js
+++ b/src/types.js
@@ -172,6 +172,8 @@ export type AndroidNativeProps = $ReadOnly<{|
   minuteInterval?: MinuteInterval,
 
   neutralButtonLabel?: string,
+  positiveButtonLabel?: string,
+  negativeButtonLabel?: string,
   onError?: (Error) => void,
 |}>;
 


### PR DESCRIPTION
Android: add custom label for positive and negative button (positiveButtonLabel, negativeButtonLabel)

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Allow user to customise android label text for positive and negative button 
via param: positiveButtonLabel, negativeButtonLabel
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
