### PR TITLE
fix(android_imports): added missing '.android'

### DIFF
--- a/src/DateTimePickerAndroid.js
+++ b/src/DateTimePickerAndroid.js
@@ -20,7 +20,7 @@ import {
   timeZoneOffsetDateSetter,
   validateAndroidProps,
 } from './androidUtils';
-import pickers from './picker';
+import pickers from './picker.android';
 
 function open(props: AndroidNativeProps) {
   const {

--- a/src/androidUtils.js
+++ b/src/androidUtils.js
@@ -3,7 +3,7 @@
  * @flow strict-local
  */
 import {ANDROID_DISPLAY, ANDROID_MODE, MIN_MS} from './constants';
-import pickers from './picker';
+import pickers from './picker.android';
 import type {AndroidNativeProps, DateTimePickerResult} from './types';
 import {sharedPropsValidation} from './utils';
 import invariant from 'invariant';

--- a/src/picker.android.js
+++ b/src/picker.android.js
@@ -2,8 +2,8 @@
  * @format
  * @flow strict-local
  */
-import DatePickerAndroid from './datepicker';
-import TimePickerAndroid from './timepicker';
+import DatePickerAndroid from './datepicker.android';
+import TimePickerAndroid from './timepicker.android';
 import {ANDROID_MODE} from './constants';
 
 const pickers = {


### PR DESCRIPTION
# Summary
- Motivation:
  - I updated Expo Sdk version and the app crashed specifically on Web, I took a look and found it was a problem related to wrong imports
- Issues resolved: 
  - https://github.com/react-native-datetimepicker/datetimepicker/issues/612
  - https://github.com/react-native-datetimepicker/datetimepicker/issues/610
 - Solution
   - Added _.android_  to each import
 - What areas of the library does it impact?
   - None 

## Test Plan

### Working feature test
Check [this video ](https://recordit.co/FWHDLqKEeH)

## Scope
Android ✅    

## Checklist
- [X] I have tested this on a device and a simulator
- [ NA] I added the documentation in `README.md`
- [NA] I updated the typed files (TS and Flow)
- [NA] I added a sample use of the API in the example project (`example/App.js`)
- [ NA] I have added automated tests, either in JS or e2e tests, as applicable
