### PR TITLE
feat: return result of android dialog dismissal

### DIFF
--- a/src/DateTimePickerAndroid.android.js
+++ b/src/DateTimePickerAndroid.android.js
@@ -98,9 +98,9 @@ function open(props: AndroidNativeProps) {
   presentPicker();
 }
 
-function dismiss(mode: AndroidNativeProps['mode']) {
+function dismiss(mode: AndroidNativeProps['mode']): Promise<boolean> {
   // $FlowFixMe - `AbstractComponent` [1] is not an instance type.
-  pickers[mode].dismiss();
+  return pickers[mode].dismiss();
 }
 
 export const DateTimePickerAndroid = {open, dismiss};

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -193,7 +193,7 @@ export type WindowsNativeProps = Readonly<
 
 declare namespace DateTimePickerAndroidType {
   const open: (args: AndroidNativeProps) => void;
-  const dismiss: (mode: AndroidNativeProps['mode']) => void;
+  const dismiss: (mode: AndroidNativeProps['mode']) => Promise<boolean>;
 }
 
 declare const RNDateTimePicker: FC<


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

On the native side, the android `dismiss` call returns a promise that the JS side does not return to the call site. 

This fixes that.


## Test Plan

tested locally

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
