### PR TITLE
Added ViewPropTypes from deprecated-react-native-prop-types

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -5,7 +5,7 @@
 
 import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 import type {HostComponent} from 'react-native';
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
+import type {ViewProps} from 'deprecated-react-native-prop-types/DeprecatedViewPropTypes';
 import type {ElementRef} from 'react';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import {


### PR DESCRIPTION
# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:
-->
* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged

https://github.com/facebook/react-native/commit/10199b158138b8645550b5579df87e654213fe42
`Image.propTypes`, `Text.propTypes`, `TextInput.propTypes`, `ColorPropType`, `EdgeInsetsPropType`, `PointPropType`, `ViewPropTypes` have been removed from react-native (>=0.69.0)
The latter (`ViewPropTypes`) is used in src/types.js

* What is the feature? (if applicable)

Patching until better fix

* How did you implement the solution?

https://www.npmjs.com/package/deprecated-react-native-prop-types/v/2.2.0
Using this library ^

* What areas of the library does it impact?

Types : src/types.js

## Test Plan

Did not do any test as my whole app depends on many packages using ViewPropTypes

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
