### PR TITLE
fix(android): time picker spinner to consider keyboard input

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
@@ -54,7 +54,7 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
 
     @Override
     public void onDateSet(DatePicker view, int year, int month, int day) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
         WritableMap result = new WritableNativeMap();
         result.putString("action", RNConstants.ACTION_DATE_SET);
         result.putInt("year", year);
@@ -67,7 +67,7 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
 
     @Override
     public void onDismiss(DialogInterface dialog) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
         WritableMap result = new WritableNativeMap();
         result.putString("action", RNConstants.ACTION_DISMISSED);
         mPromise.resolve(result);
@@ -77,7 +77,7 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
 
     @Override
     public void onClick(DialogInterface dialog, int which) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
         WritableMap result = new WritableNativeMap();
         result.putString("action", RNConstants.ACTION_NEUTRAL_BUTTON);
         mPromise.resolve(result);

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
@@ -15,10 +15,10 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
 import android.content.DialogInterface.OnClickListener;
-import android.os.Build;
 import android.os.Bundle;
 import android.text.format.DateFormat;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 
@@ -35,6 +35,7 @@ public class RNTimePickerDialogFragment extends DialogFragment {
   @Nullable
   private static OnClickListener mOnNeutralButtonActionListener;
 
+  @NonNull
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
     final Bundle args = getArguments();
@@ -116,7 +117,7 @@ public class RNTimePickerDialogFragment extends DialogFragment {
   }
 
   @Override
-  public void onDismiss(DialogInterface dialog) {
+  public void onDismiss(@NonNull DialogInterface dialog) {
     super.onDismiss(dialog);
     if (mOnDismissListener != null) {
       mOnDismissListener.onDismiss(dialog);

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
@@ -19,6 +19,7 @@ import android.content.DialogInterface.OnClickListener;
 import android.os.Bundle;
 import android.widget.TimePicker;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -39,6 +40,7 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
     super(reactContext);
   }
 
+  @NonNull
   @Override
   public String getName() {
     return FRAGMENT_TAG;
@@ -54,7 +56,7 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
 
     @Override
     public void onTimeSet(TimePicker view, int hour, int minute) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
         WritableMap result = new WritableNativeMap();
         result.putString("action", RNConstants.ACTION_TIME_SET);
         result.putInt("hour", hour);
@@ -66,7 +68,7 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
 
     @Override
     public void onDismiss(DialogInterface dialog) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
         WritableMap result = new WritableNativeMap();
         result.putString("action", RNConstants.ACTION_DISMISSED);
         mPromise.resolve(result);
@@ -76,7 +78,7 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
 
     @Override
     public void onClick(DialogInterface dialog, int which) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveCatalystInstance()) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
         WritableMap result = new WritableNativeMap();
         result.putString("action", RNConstants.ACTION_NEUTRAL_BUTTON);
         mPromise.resolve(result);

--- a/example/App.js
+++ b/example/App.js
@@ -6,6 +6,7 @@ import {
   Text,
   StatusBar,
   Button,
+  Alert,
   Platform,
   TextInput,
   useColorScheme,
@@ -103,6 +104,12 @@ export const App = () => {
     if (event.type === 'neutralButtonPressed') {
       setDate(new Date(0));
     } else {
+      Alert.alert(
+        'event: ',
+        `${event.type} ${selectedDate.toLocaleString()}`,
+        [],
+        {cancelable: true},
+      );
       setDate(currentDate);
     }
   };

--- a/example/App.js
+++ b/example/App.js
@@ -6,7 +6,6 @@ import {
   Text,
   StatusBar,
   Button,
-  Alert,
   Platform,
   TextInput,
   useColorScheme,
@@ -104,12 +103,6 @@ export const App = () => {
     if (event.type === 'neutralButtonPressed') {
       setDate(new Date(0));
     } else {
-      Alert.alert(
-        'event: ',
-        `${event.type} ${selectedDate.toLocaleString()}`,
-        [],
-        {cancelable: true},
-      );
       setDate(currentDate);
     }
   };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

closes #606 

as an alternative we can disable the input using `time /date picker .setDescendantFocusability(ViewGroup.FOCUS_BLOCK_DESCENDANTS)`

## Test Plan

tested manually using example app

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
