### PR TITLE
fix(android): improve spinner buttons contrast

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,14 @@ React Native date & time picker component for iOS, Android and Windows.
 ## Requirements
 
 - Only Android API level >=21 (Android 5), iOS >= 11 are supported.
-- Tested with Xcode 13.0 and RN 0.66.3. Other configurations are very likely to work as well but have not been tested.
+- Tested with Xcode 14.0 and RN 0.70. Other configurations are very likely to work as well but have not been tested.
 
 ## Expo users notice
 
-This module is part of Expo - [see docs](https://docs.expo.io/versions/latest/sdk/date-time-picker/). However, Expo SDK may not contain the latest version of the module and therefore, the newest features and bugfixes may not be available in Expo. Use the command `expo install @react-native-community/datetimepicker` (not `yarn` or `npm`) to install this module - Expo will automatically install the latest version compatible with your Expo SDK (which may _not_ be the latest version of the module available).
+This module is part of Expo Managed Workflow - [see docs](https://docs.expo.io/versions/latest/sdk/date-time-picker/). However, Expo SDK in the Managed Workflow may not contain the latest version of the module and therefore, the newest features and bugfixes may not be available in Expo Managed Workflow.
+If you use the Managed Workflow, use the command `expo install @react-native-community/datetimepicker` (not `yarn` or `npm`) to install this module - Expo will automatically install the latest version compatible with your Expo SDK (which may _not_ be the latest version of the module available).
+
+If you're using the [`expo prebuild`](https://docs.expo.dev/workflow/prebuild/) command and building your native app projects (e.g. with EAS Build or locally), you can use the latest version of the module.
 
 ## Getting started
 

--- a/android/src/main/res/values-night/styles.xml
+++ b/android/src/main/res/values-night/styles.xml
@@ -1,0 +1,9 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+	<style name="SpinnerDatePickerDialog" parent="SpinnerDatePickerDialogBase">
+		<item name="colorPrimary">@android:color/white</item>
+	</style>
+
+	<style name="SpinnerTimePickerDialog" parent="SpinnerTimePickerDialogBase">
+		<item name="colorPrimary">@android:color/white</item>
+	</style>
+</resources>

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,8 +1,9 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="SpinnerDatePickerDialog" tools:targetApi="lollipop">
+    <style name="SpinnerDatePickerDialogBase" tools:targetApi="lollipop">
         <item name="android:datePickerStyle">@style/SpinnerDatePickerStyle</item>
 		<item name="android:windowIsFloating">true</item>
     </style>
+    <style name="SpinnerDatePickerDialog" parent="SpinnerDatePickerDialogBase" />
 
     <style name="SpinnerDatePickerStyle" parent="android:Widget.Material.DatePicker" tools:targetApi="lollipop">
         <item name="android:datePickerMode">spinner</item>
@@ -25,10 +26,11 @@
         <item name="android:timePickerMode">clock</item>
     </style>
 
-    <style name="SpinnerTimePickerDialog" tools:targetApi="lollipop">
+    <style name="SpinnerTimePickerDialogBase" tools:targetApi="lollipop">
         <item name="android:timePickerStyle">@style/SpinnerTimePickerStyle</item>
 		<item name="android:windowIsFloating">true</item>
     </style>
+	<style name="SpinnerTimePickerDialog" parent="SpinnerTimePickerDialogBase" />
 
     <style name="SpinnerTimePickerStyle" parent="android:Widget.Material.TimePicker" tools:targetApi="lollipop">
         <item name="android:timePickerMode">spinner</item>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

follow up on #673 which increases the button text contrast in dark mode

<details>
    <summary>screenshot</summary>

![dark-contrast](https://user-images.githubusercontent.com/1566403/196029039-28de2650-113d-4a73-961c-19624cd2e3e5.png)

</details>

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
