### PR TITLE
fix: only apply button text color fix to spinner

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+indent_style = space
+indent_size = 2
+
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -496,12 +496,6 @@ Callback that is called when an error occurs inside the date picker native code 
 
 ## Testing with Jest
 
-If you're rendering the picker component (using the `@testing-library/react-native` or similar), you need to mock the native module:
-
-```
-"setupFiles": ["./node_modules/@react-native-community/datetimepicker/jest/setup.js"]
-```
-
 For examples of how you can write your tests, look [here](/test/userlandTestExamples.test.js).
 
 ## Migration from the older components

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java
@@ -5,6 +5,7 @@ import android.app.DatePickerDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.res.Resources;
+import android.os.Bundle;
 import android.util.TypedValue;
 import android.widget.Button;
 
@@ -17,6 +18,8 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
 import com.facebook.react.bridge.Promise;
+
+import java.util.Locale;
 
 public class Common {
 
@@ -70,4 +73,20 @@ public class Common {
 			}
 		};
 	}
+
+  public static RNTimePickerDisplay getDisplayTime(Bundle args) {
+    RNTimePickerDisplay display = RNTimePickerDisplay.DEFAULT;
+    if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
+      display = RNTimePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
+    }
+    return display;
+  }
+
+  public static RNDatePickerDisplay getDisplayDate(Bundle args) {
+    RNDatePickerDisplay display = RNDatePickerDisplay.DEFAULT;
+    if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
+      display = RNDatePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
+    }
+    return display;
+  }
 }

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java
@@ -57,21 +57,26 @@ public class Common {
 
 	@NonNull
 	public static DialogInterface.OnShowListener setButtonTextColor(@NonNull Context activityContext, final AlertDialog dialog) {
-		return presentedDialog -> {
-			int textColorPrimary = getDefaultDialogButtonTextColor(activityContext);
-			Button positiveButton = dialog.getButton(DatePickerDialog.BUTTON_POSITIVE);
-			if (positiveButton != null) {
-				positiveButton.setTextColor(textColorPrimary);
-			}
-			Button negativeButton = dialog.getButton(DatePickerDialog.BUTTON_NEGATIVE);
-			if (negativeButton != null) {
-				negativeButton.setTextColor(textColorPrimary);
-			}
-			Button neutralButton = dialog.getButton(DatePickerDialog.BUTTON_NEUTRAL);
-			if (neutralButton != null) {
-				neutralButton.setTextColor(textColorPrimary);
-			}
-		};
+    return new DialogInterface.OnShowListener() {
+      @Override
+      public void onShow(DialogInterface dialogInterface) {
+        Button positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
+        Button negativeButton = dialog.getButton(AlertDialog.BUTTON_NEGATIVE);
+        Button neutralButton = dialog.getButton(AlertDialog.BUTTON_NEUTRAL);
+
+        int textColorPrimary = getDefaultDialogButtonTextColor(activityContext);
+
+        if (positiveButton != null) {
+          positiveButton.setTextColor(textColorPrimary);
+        }
+        if (negativeButton != null) {
+          negativeButton.setTextColor(textColorPrimary);
+        }
+        if (neutralButton != null) {
+          neutralButton.setTextColor(textColorPrimary);
+        }
+      }
+    };
 	}
 
   public static RNTimePickerDisplay getDisplayTime(Bundle args) {

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
@@ -7,6 +7,7 @@
 
 package com.reactcommunity.rndatetimepicker;
 
+import static com.reactcommunity.rndatetimepicker.Common.getDisplayDate;
 import static com.reactcommunity.rndatetimepicker.Common.setButtonTextColor;
 
 import android.annotation.SuppressLint;
@@ -39,6 +40,7 @@ public class RNDatePickerDialogFragment extends DialogFragment {
   @Nullable
   private static OnClickListener mOnNeutralButtonActionListener;
 
+  @NonNull
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
     Bundle args = getArguments();
@@ -62,33 +64,31 @@ public class RNDatePickerDialogFragment extends DialogFragment {
     final int month = date.month();
     final int day = date.day();
 
-    RNDatePickerDisplay display = RNDatePickerDisplay.DEFAULT;
+    RNDatePickerDisplay display = getDisplayDate(args);
 
     if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
       display = RNDatePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
     }
 
-    switch (display) {
-      case SPINNER:
-        return new RNDismissableDatePickerDialog(
-                activityContext,
-				R.style.SpinnerDatePickerDialog,
-                onDateSetListener,
-                year,
-                month,
-                day,
-                display
-        );
-      default:
-        return new RNDismissableDatePickerDialog(
-                activityContext,
-                onDateSetListener,
-                year,
-                month,
-                day,
-                display
-        );
+    if (display == RNDatePickerDisplay.SPINNER) {
+      return new RNDismissableDatePickerDialog(
+        activityContext,
+        R.style.SpinnerDatePickerDialog,
+        onDateSetListener,
+        year,
+        month,
+        day,
+        display
+      );
     }
+    return new RNDismissableDatePickerDialog(
+      activityContext,
+      onDateSetListener,
+      year,
+      month,
+      day,
+      display
+    );
   }
 
   static DatePickerDialog createDialog(
@@ -100,18 +100,23 @@ public class RNDatePickerDialogFragment extends DialogFragment {
 
     DatePickerDialog dialog = getDialog(args, activityContext, onDateSetListener);
 
-    if (args != null && args.containsKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
-      dialog.setButton(DialogInterface.BUTTON_NEUTRAL, args.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL), mOnNeutralButtonActionListener);
-    }
-    if (args != null && args.containsKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
-      dialog.setButton(DialogInterface.BUTTON_POSITIVE, args.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL), dialog);
-    }
-    if (args != null && args.containsKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
-      dialog.setButton(DialogInterface.BUTTON_NEGATIVE, args.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL), dialog);
+    if (args != null) {
+      if (args.containsKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
+        dialog.setButton(DialogInterface.BUTTON_NEUTRAL, args.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL), mOnNeutralButtonActionListener);
+      }
+      if (args.containsKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
+        dialog.setButton(DialogInterface.BUTTON_POSITIVE, args.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL), dialog);
+      }
+      if (args.containsKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
+        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, args.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL), dialog);
+      }
+      RNDatePickerDisplay display = getDisplayDate(args);
+      if (display == RNDatePickerDisplay.SPINNER) {
+        dialog.setOnShowListener(setButtonTextColor(activityContext, dialog));
+      }
     }
 
     final DatePicker datePicker = dialog.getDatePicker();
-	dialog.setOnShowListener(setButtonTextColor(activityContext, dialog));
 
     Integer timeZoneOffsetInMilliseconds = getTimeZoneOffset(args);
     if (timeZoneOffsetInMilliseconds != null) {
@@ -164,7 +169,7 @@ public class RNDatePickerDialogFragment extends DialogFragment {
   }
 
   @Override
-  public void onDismiss(DialogInterface dialog) {
+  public void onDismiss(@NonNull DialogInterface dialog) {
     super.onDismiss(dialog);
     if (mOnDismissListener != null) {
       mOnDismissListener.onDismiss(dialog);

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
@@ -8,6 +8,7 @@
 
 package com.reactcommunity.rndatetimepicker;
 
+import static com.reactcommunity.rndatetimepicker.Common.getDisplayTime;
 import static com.reactcommunity.rndatetimepicker.Common.setButtonTextColor;
 
 import android.app.Dialog;
@@ -23,8 +24,6 @@ import android.text.format.DateFormat;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
-
-import java.util.Locale;
 
 @SuppressWarnings("ValidFragment")
 public class RNTimePickerDialogFragment extends DialogFragment {
@@ -65,14 +64,7 @@ public class RNTimePickerDialogFragment extends DialogFragment {
       minuteInterval = args.getInt(RNConstants.ARG_INTERVAL);
     }
 
-    RNTimePickerDisplay display = RNTimePickerDisplay.DEFAULT;
-    if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
-      display = RNTimePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
-    }
-
-    if (args != null) {
-      is24hour = args.getBoolean(RNConstants.ARG_IS24HOUR, DateFormat.is24HourFormat(activityContext));
-    }
+    RNTimePickerDisplay display = getDisplayTime(args);
 
     if (display == RNTimePickerDisplay.SPINNER) {
         return new RNDismissableTimePickerDialog(
@@ -103,16 +95,21 @@ public class RNTimePickerDialogFragment extends DialogFragment {
 
     TimePickerDialog dialog = getDialog(args, activityContext, onTimeSetListener);
 
-    if (args != null && args.containsKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
-      dialog.setButton(DialogInterface.BUTTON_NEUTRAL, args.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL), mOnNeutralButtonActionListener);
+    if (args != null) {
+      if (args.containsKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
+        dialog.setButton(DialogInterface.BUTTON_NEUTRAL, args.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL), mOnNeutralButtonActionListener);
+      }
+      if (args.containsKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
+        dialog.setButton(DialogInterface.BUTTON_POSITIVE, args.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL), dialog);
+      }
+      if (args.containsKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
+        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, args.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL), dialog);
+      }
+      RNTimePickerDisplay display = getDisplayTime(args);
+      if (display == RNTimePickerDisplay.SPINNER) {
+        dialog.setOnShowListener(setButtonTextColor(activityContext, dialog));
+      }
     }
-    if (args != null && args.containsKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
-      dialog.setButton(DialogInterface.BUTTON_POSITIVE, args.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL), dialog);
-    }
-    if (args != null && args.containsKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
-      dialog.setButton(DialogInterface.BUTTON_NEGATIVE, args.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL), dialog);
-    }
-	dialog.setOnShowListener(setButtonTextColor(activityContext, dialog));
     return dialog;
   }
 

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
@@ -58,6 +58,9 @@ public class RNTimePickerDialogFragment extends DialogFragment {
     final int hour = date.hour();
     final int minute = date.minute();
     boolean is24hour = DateFormat.is24HourFormat(activityContext);
+    if (args != null) {
+      is24hour = args.getBoolean(RNConstants.ARG_IS24HOUR, DateFormat.is24HourFormat(activityContext));
+    }
 
     int minuteInterval = RNConstants.DEFAULT_TIME_PICKER_INTERVAL;
     if (args != null && MinuteIntervalSnappableTimePickerDialog.isValidMinuteInterval(args.getInt(RNConstants.ARG_INTERVAL))) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -57,5 +57,4 @@ export const DATE_SET_ACTION = 'dateSetAction';
 export const TIME_SET_ACTION = 'timeSetAction';
 export const DISMISS_ACTION = 'dismissedAction';
 
-export const NEUTRAL_BUTTON_LABEL = 'neutralButtonLabel';
 export const NEUTRAL_BUTTON_ACTION = 'neutralButtonAction';

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -13,9 +13,9 @@ import RNDateTimePicker from './picker';
 import {dateToMilliseconds, sharedPropsValidation} from './utils';
 import {
   IOS_DISPLAY,
-  ANDROID_MODE,
   EVENT_TYPE_SET,
   EVENT_TYPE_DISMISSED,
+  IOS_MODE,
 } from './constants';
 import * as React from 'react';
 import {Platform} from 'react-native';
@@ -56,7 +56,7 @@ export default function Picker({
   accentColor,
   themeVariant,
   onChange,
-  mode = ANDROID_MODE.date,
+  mode = IOS_MODE.date,
   display: providedDisplay = IOS_DISPLAY.default,
   disabled = false,
 }: IOSNativeProps): React.Node {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This is a follow-up on #680 where I overrode the button text color for all types of pickers, where the intention was to override it only for spinner pickers which suffered from button text not visible.

When someone styles their pickers from xml, that would break the styling, and this should fix it..

also closes #684

The PR also brings in some other code simplifications and improvements.


## Test Plan

tested locally

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ❌     |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
