### PR TITLE
feat: android dialog buttons text color

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,32 @@ Allows changing of the time picker to a 24-hour format. By default, this value i
 <RNDateTimePicker is24Hour={true} />
 ```
 
-#### `positiveButtonLabel` (`optional`, `Android only`)
+#### `positiveButton` (`optional`, `Android only`)
+
+Set the positive button label and text color.
+
+```js
+<RNDateTimePicker positiveButton={{label: 'OK', textColor: 'green'}} />
+```
+
+#### `neutralButton` (`optional`, `Android only`)
+
+Allows displaying neutral button on picker dialog.
+Pressing button can be observed in onChange handler as `event.type === 'neutralButtonPressed'`
+
+```js
+<RNDateTimePicker neutralButton={{label: 'Clear', textColor: 'red'}} />
+```
+
+#### `negativeButton` (`optional`, `Android only`)
+
+Set the negative button label and text color.
+
+```js
+<RNDateTimePicker negativeButton={{label: 'Cancel', textColor: 'red'}} />
+```
+
+#### `positiveButtonLabel` (`optional`, `Android only`, deprecated)
 
 Changes the label of the positive button.
 
@@ -442,7 +467,7 @@ Changes the label of the positive button.
 <RNDateTimePicker positiveButtonLabel="OK!" />
 ```
 
-#### `negativeButtonLabel` (`optional`, `Android only`)
+#### `negativeButtonLabel` (`optional`, `Android only`, deprecated)
 
 Changes the label of the negative button.
 
@@ -450,7 +475,7 @@ Changes the label of the negative button.
 <RNDateTimePicker positiveButtonLabel="Negative" />
 ```
 
-#### `neutralButtonLabel` (`optional`, `Android only`)
+#### `neutralButtonLabel` (`optional`, `Android only`, deprecated)
 
 Allows displaying neutral button on picker dialog.
 Pressing button can be observed in onChange handler as `event.type === 'neutralButtonPressed'`

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java
@@ -2,9 +2,11 @@ package com.reactcommunity.rndatetimepicker;
 
 import android.app.AlertDialog;
 import android.app.DatePickerDialog;
+import android.app.TimePickerDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.res.Resources;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.util.TypedValue;
 import android.widget.Button;
@@ -22,6 +24,12 @@ import com.facebook.react.bridge.Promise;
 import java.util.Locale;
 
 public class Common {
+
+  public static final String POSITIVE = "positive";
+  public static final String NEUTRAL = "neutral";
+  public static final String NEGATIVE = "negative";
+  public static final String LABEL = "label";
+  public static final String TEXT_COLOR = "textColor";
 
   public static void dismissDialog(FragmentActivity activity, String fragmentTag, Promise promise) {
     if (activity == null) {
@@ -56,10 +64,12 @@ public class Common {
 	}
 
 	@NonNull
-	public static DialogInterface.OnShowListener setButtonTextColor(@NonNull Context activityContext, final AlertDialog dialog) {
+	public static DialogInterface.OnShowListener setButtonTextColor(@NonNull Context activityContext, final AlertDialog dialog, final Bundle args, final boolean needsColorOverride) {
     return new DialogInterface.OnShowListener() {
       @Override
       public void onShow(DialogInterface dialogInterface) {
+        // change text color only if custom color is set or if spinner mode is set
+
         Button positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
         Button negativeButton = dialog.getButton(AlertDialog.BUTTON_NEGATIVE);
         Button neutralButton = dialog.getButton(AlertDialog.BUTTON_NEUTRAL);
@@ -67,17 +77,43 @@ public class Common {
         int textColorPrimary = getDefaultDialogButtonTextColor(activityContext);
 
         if (positiveButton != null) {
-          positiveButton.setTextColor(textColorPrimary);
+          Integer color = getButtonColor(args, POSITIVE);
+          if (needsColorOverride || color != null) {
+            positiveButton.setTextColor(color != null ? color : textColorPrimary);
+          }
         }
         if (negativeButton != null) {
-          negativeButton.setTextColor(textColorPrimary);
+          Integer color = getButtonColor(args, NEGATIVE);
+          if (needsColorOverride || color != null) {
+            negativeButton.setTextColor(color != null ? color : textColorPrimary);
+          }
         }
         if (neutralButton != null) {
-          neutralButton.setTextColor(textColorPrimary);
+          Integer color = getButtonColor(args, NEUTRAL);
+          if (needsColorOverride || color != null) {
+            neutralButton.setTextColor(color != null ? color : textColorPrimary);
+          }
         }
       }
     };
 	}
+
+  public static Integer getButtonColor(final Bundle args, String buttonKey) {
+    Bundle buttons = args.getBundle(RNConstants.ARG_DIALOG_BUTTONS);
+    if (buttons == null) {
+      return null;
+    }
+    Bundle buttonParams = buttons.getBundle(buttonKey);
+    if (buttonParams == null) {
+      return null;
+    }
+    // yes, this cast is safe because the color is passed as int from JS
+    int color = (int) buttonParams.getDouble(TEXT_COLOR, Color.TRANSPARENT);
+    if (color == Color.TRANSPARENT) {
+      return null;
+    }
+    return color;
+  }
 
   public static RNTimePickerDisplay getDisplayTime(Bundle args) {
     RNTimePickerDisplay display = RNTimePickerDisplay.DEFAULT;
@@ -93,5 +129,24 @@ public class Common {
       display = RNDatePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
     }
     return display;
+  }
+
+  public static void setButtonTitles(@NonNull Bundle args, AlertDialog dialog, DialogInterface.OnClickListener onNeutralButtonActionListener) {
+    Bundle buttons = args.getBundle(RNConstants.ARG_DIALOG_BUTTONS);
+    if (buttons == null) {
+      return;
+    }
+    Bundle neutralButton = buttons.getBundle(NEUTRAL);
+    Bundle positiveButton = buttons.getBundle(POSITIVE);
+    Bundle negativeButton = buttons.getBundle(NEGATIVE);
+    if (neutralButton != null && neutralButton.getString(LABEL) != null) {
+      dialog.setButton(DialogInterface.BUTTON_NEUTRAL, neutralButton.getString(LABEL), onNeutralButtonActionListener);
+    }
+    if (positiveButton != null && positiveButton.getString(LABEL) != null) {
+      dialog.setButton(DialogInterface.BUTTON_POSITIVE, positiveButton.getString(LABEL), (DialogInterface.OnClickListener) dialog);
+    }
+    if (negativeButton != null && negativeButton.getString(LABEL) != null) {
+      dialog.setButton(DialogInterface.BUTTON_NEGATIVE, negativeButton.getString(LABEL), (DialogInterface.OnClickListener) dialog);
+    }
   }
 }

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNConstants.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNConstants.java
@@ -1,5 +1,7 @@
 package com.reactcommunity.rndatetimepicker;
 
+import android.app.TimePickerDialog;
+
 public final class RNConstants {
   public static final String ERROR_NO_ACTIVITY = "E_NO_ACTIVITY";
   public static final String ARG_VALUE = "value";
@@ -8,9 +10,7 @@ public final class RNConstants {
   public static final String ARG_INTERVAL = "minuteInterval";
   public static final String ARG_IS24HOUR = "is24Hour";
   public static final String ARG_DISPLAY = "display";
-  public static final String ARG_NEUTRAL_BUTTON_LABEL = "neutralButtonLabel";
-  public static final String ARG_POSITIVE_BUTTON_LABEL = "positiveButtonLabel";
-  public static final String ARG_NEGATIVE_BUTTON_LABEL = "negativeButtonLabel";
+  public static final String ARG_DIALOG_BUTTONS = "dialogButtons";
   public static final String ARG_TZOFFSET_MINS = "timeZoneOffsetInMinutes";
   public static final String ACTION_DATE_SET = "dateSetAction";
   public static final String ACTION_TIME_SET = "timeSetAction";
@@ -18,7 +18,7 @@ public final class RNConstants {
   public static final String ACTION_NEUTRAL_BUTTON = "neutralButtonAction";
 
   /**
-   * Minimum date supported by {@link DatePicker}, 01 Jan 1900
+   * Minimum date supported by {@link TimePickerDialog}, 01 Jan 1900
    */
   public static final long DEFAULT_MIN_DATE = -2208988800001l;
 

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
@@ -9,6 +9,7 @@ package com.reactcommunity.rndatetimepicker;
 
 import static com.reactcommunity.rndatetimepicker.Common.getDisplayDate;
 import static com.reactcommunity.rndatetimepicker.Common.setButtonTextColor;
+import static com.reactcommunity.rndatetimepicker.Common.setButtonTitles;
 
 import android.annotation.SuppressLint;
 import android.app.DatePickerDialog;
@@ -38,13 +39,13 @@ public class RNDatePickerDialogFragment extends DialogFragment {
   @Nullable
   private OnDismissListener mOnDismissListener;
   @Nullable
-  private static OnClickListener mOnNeutralButtonActionListener;
+  private OnClickListener mOnNeutralButtonActionListener;
 
   @NonNull
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
     Bundle args = getArguments();
-    instance = createDialog(args, getActivity(), mOnDateSetListener);
+    instance = createDialog(args);
     return instance;
   }
 
@@ -91,28 +92,18 @@ public class RNDatePickerDialogFragment extends DialogFragment {
     );
   }
 
-  static DatePickerDialog createDialog(
-          Bundle args,
-          Context activityContext,
-          @Nullable OnDateSetListener onDateSetListener) {
-
+  private DatePickerDialog createDialog(Bundle args) {
+    Context activityContext = getActivity();
     final Calendar c = Calendar.getInstance();
 
-    DatePickerDialog dialog = getDialog(args, activityContext, onDateSetListener);
+    DatePickerDialog dialog = getDialog(args, activityContext, mOnDateSetListener);
 
     if (args != null) {
-      if (args.containsKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
-        dialog.setButton(DialogInterface.BUTTON_NEUTRAL, args.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL), mOnNeutralButtonActionListener);
-      }
-      if (args.containsKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
-        dialog.setButton(DialogInterface.BUTTON_POSITIVE, args.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL), dialog);
-      }
-      if (args.containsKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
-        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, args.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL), dialog);
-      }
-      RNDatePickerDisplay display = getDisplayDate(args);
-      if (display == RNDatePickerDisplay.SPINNER) {
-        dialog.setOnShowListener(setButtonTextColor(activityContext, dialog));
+      setButtonTitles(args, dialog, mOnNeutralButtonActionListener);
+      if (activityContext != null) {
+        RNDatePickerDisplay display = getDisplayDate(args);
+        boolean needsColorOverride = display == RNDatePickerDisplay.SPINNER;
+        dialog.setOnShowListener(setButtonTextColor(activityContext, dialog, args, needsColorOverride));
       }
     }
 

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogModule.java
@@ -168,14 +168,8 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
     if (options.hasKey(RNConstants.ARG_DISPLAY) && !options.isNull(RNConstants.ARG_DISPLAY)) {
       args.putString(RNConstants.ARG_DISPLAY, options.getString(RNConstants.ARG_DISPLAY));
     }
-    if (options.hasKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
-      args.putString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL, options.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL));
-    }
-    if (options.hasKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
-      args.putString(RNConstants.ARG_POSITIVE_BUTTON_LABEL, options.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL));
-    }
-    if (options.hasKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
-      args.putString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL, options.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL));
+    if (options.hasKey(RNConstants.ARG_DIALOG_BUTTONS) && !options.isNull(RNConstants.ARG_DIALOG_BUTTONS)) {
+      args.putBundle(RNConstants.ARG_DIALOG_BUTTONS, Arguments.toBundle(options.getMap(RNConstants.ARG_DIALOG_BUTTONS)));
     }
     if (options.hasKey(RNConstants.ARG_TZOFFSET_MINS) && !options.isNull(RNConstants.ARG_TZOFFSET_MINS)) {
       args.putLong(RNConstants.ARG_TZOFFSET_MINS, (long) options.getDouble(RNConstants.ARG_TZOFFSET_MINS));

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogFragment.java
@@ -10,6 +10,7 @@ package com.reactcommunity.rndatetimepicker;
 
 import static com.reactcommunity.rndatetimepicker.Common.getDisplayTime;
 import static com.reactcommunity.rndatetimepicker.Common.setButtonTextColor;
+import static com.reactcommunity.rndatetimepicker.Common.setButtonTitles;
 
 import android.app.Dialog;
 import android.app.TimePickerDialog;
@@ -34,13 +35,13 @@ public class RNTimePickerDialogFragment extends DialogFragment {
   @Nullable
   private OnDismissListener mOnDismissListener;
   @Nullable
-  private static OnClickListener mOnNeutralButtonActionListener;
+  private OnClickListener mOnNeutralButtonActionListener;
 
   @NonNull
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
     final Bundle args = getArguments();
-    instance = createDialog(args, getActivity(), mOnTimeSetListener);
+    instance = createDialog(args);
     return instance;
   }
 
@@ -92,25 +93,16 @@ public class RNTimePickerDialogFragment extends DialogFragment {
     );
   }
 
-  static TimePickerDialog createDialog(
-          Bundle args, Context activityContext,
-          @Nullable OnTimeSetListener onTimeSetListener) {
-
-    TimePickerDialog dialog = getDialog(args, activityContext, onTimeSetListener);
+  private TimePickerDialog createDialog(Bundle args) {
+    Context activityContext = getActivity();
+    TimePickerDialog dialog = getDialog(args, activityContext, mOnTimeSetListener);
 
     if (args != null) {
-      if (args.containsKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
-        dialog.setButton(DialogInterface.BUTTON_NEUTRAL, args.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL), mOnNeutralButtonActionListener);
-      }
-      if (args.containsKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
-        dialog.setButton(DialogInterface.BUTTON_POSITIVE, args.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL), dialog);
-      }
-      if (args.containsKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
-        dialog.setButton(DialogInterface.BUTTON_NEGATIVE, args.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL), dialog);
-      }
-      RNTimePickerDisplay display = getDisplayTime(args);
-      if (display == RNTimePickerDisplay.SPINNER) {
-        dialog.setOnShowListener(setButtonTextColor(activityContext, dialog));
+      setButtonTitles(args, dialog, mOnNeutralButtonActionListener);
+      if (activityContext != null) {
+        RNTimePickerDisplay display = getDisplayTime(args);
+        boolean needsColorOverride = display == RNTimePickerDisplay.SPINNER;
+        dialog.setOnShowListener(setButtonTextColor(activityContext, dialog, args, needsColorOverride));
       }
     }
     return dialog;

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
@@ -144,14 +144,8 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
     if (options.hasKey(RNConstants.ARG_DISPLAY) && !options.isNull(RNConstants.ARG_DISPLAY)) {
       args.putString(RNConstants.ARG_DISPLAY, options.getString(RNConstants.ARG_DISPLAY));
     }
-    if (options.hasKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
-      args.putString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL, options.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL));
-    }
-    if (options.hasKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
-      args.putString(RNConstants.ARG_POSITIVE_BUTTON_LABEL, options.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL));
-    }
-    if (options.hasKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
-      args.putString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL, options.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL));
+    if (options.hasKey(RNConstants.ARG_DIALOG_BUTTONS) && !options.isNull(RNConstants.ARG_DIALOG_BUTTONS)) {
+      args.putBundle(RNConstants.ARG_DIALOG_BUTTONS, Arguments.toBundle(options.getMap(RNConstants.ARG_DIALOG_BUTTONS)));
     }
     if (options.hasKey(RNConstants.ARG_INTERVAL) && !options.isNull(RNConstants.ARG_INTERVAL)) {
       args.putInt(RNConstants.ARG_INTERVAL, options.getInt(RNConstants.ARG_INTERVAL));

--- a/example/App.js
+++ b/example/App.js
@@ -96,7 +96,6 @@ export const App = () => {
   };
 
   const onChange = (event, selectedDate) => {
-    const currentDate = selectedDate || date;
     if (Platform.OS === 'android') {
       setShow(false);
     }
@@ -117,7 +116,7 @@ export const App = () => {
     if (event.type === 'neutralButtonPressed') {
       setDate(new Date(0));
     } else {
-      setDate(currentDate);
+      setDate(selectedDate);
     }
   };
 
@@ -353,7 +352,8 @@ export const App = () => {
                   onChange={onChange}
                   textColor={textColor || undefined}
                   accentColor={accentColor || undefined}
-                  neutralButtonLabel={neutralButtonLabel}
+                  neutralButton={{label: neutralButtonLabel}}
+                  negativeButton={{label: 'Cancel', textColor: 'red'}}
                   disabled={disabled}
                 />
               )}

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -18,7 +18,14 @@ buildscript {
     }
 }
 
+def REACT_NATIVE_VERSION = new File(['node', '--print',"JSON.parse(require('fs').readFileSync(require.resolve('react-native/package.json'), 'utf-8')).version"].execute(null, rootDir).text.trim())
+
 allprojects {
+    configurations.all {
+      resolutionStrategy {
+        force "com.facebook.react:react-native:" + REACT_NATIVE_VERSION
+      }
+    }
     repositories {
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm

--- a/src/DateTimePickerAndroid.android.js
+++ b/src/DateTimePickerAndroid.android.js
@@ -24,6 +24,7 @@ import {
   createDismissEvtParams,
   createNeutralEvtParams,
 } from './eventCreators';
+import {processColor} from 'react-native';
 
 function open(props: AndroidNativeProps) {
   const {
@@ -37,6 +38,9 @@ function open(props: AndroidNativeProps) {
     timeZoneOffsetInMinutes,
     onChange,
     onError,
+    positiveButton,
+    negativeButton,
+    neutralButton,
     neutralButtonLabel,
     positiveButtonLabel,
     negativeButtonLabel,
@@ -49,6 +53,24 @@ function open(props: AndroidNativeProps) {
 
   const presentPicker = async () => {
     try {
+      const dialogButtons = {
+        positive: {
+          label: positiveButtonLabel,
+          ...positiveButton,
+          textColor: processColor(positiveButton?.textColor),
+        },
+        neutral: {
+          label: neutralButtonLabel,
+          ...neutralButton,
+          textColor: processColor(neutralButton?.textColor),
+        },
+        negative: {
+          label: negativeButtonLabel,
+          ...negativeButton,
+          textColor: processColor(negativeButton?.textColor),
+        },
+      };
+
       const displayOverride =
         display === ANDROID_DISPLAY.spinner
           ? ANDROID_DISPLAY.spinner
@@ -61,9 +83,7 @@ function open(props: AndroidNativeProps) {
         maximumDate,
         minuteInterval,
         timeZoneOffsetInMinutes,
-        neutralButtonLabel,
-        positiveButtonLabel,
-        negativeButtonLabel,
+        dialogButtons,
       });
 
       switch (action) {

--- a/src/androidUtils.js
+++ b/src/androidUtils.js
@@ -16,11 +16,9 @@ type Params = {
   is24Hour: AndroidNativeProps['is24Hour'],
   minimumDate: AndroidNativeProps['minimumDate'],
   maximumDate: AndroidNativeProps['maximumDate'],
-  neutralButtonLabel: AndroidNativeProps['neutralButtonLabel'],
   minuteInterval: AndroidNativeProps['minuteInterval'],
   timeZoneOffsetInMinutes: AndroidNativeProps['timeZoneOffsetInMinutes'],
-  positiveButtonLabel: AndroidNativeProps['positiveButtonLabel'],
-  negativeButtonLabel: AndroidNativeProps['negativeButtonLabel'],
+  dialogButtons: AndroidNativeProps['dialogButtons'],
 };
 
 export type PresentPickerCallback = (Params) => Promise<DateTimePickerResult>;
@@ -36,9 +34,7 @@ function getOpenPicker(
         is24Hour,
         minuteInterval,
         timeZoneOffsetInMinutes,
-        neutralButtonLabel,
-        positiveButtonLabel,
-        negativeButtonLabel,
+        dialogButtons,
       }: Params) =>
         // $FlowFixMe - `AbstractComponent` [1] is not an instance type.
         pickers[mode].open({
@@ -47,9 +43,7 @@ function getOpenPicker(
           minuteInterval,
           is24Hour,
           timeZoneOffsetInMinutes,
-          neutralButtonLabel,
-          positiveButtonLabel,
-          negativeButtonLabel,
+          dialogButtons,
         });
     default:
       return ({
@@ -58,9 +52,7 @@ function getOpenPicker(
         minimumDate,
         maximumDate,
         timeZoneOffsetInMinutes,
-        neutralButtonLabel,
-        positiveButtonLabel,
-        negativeButtonLabel,
+        dialogButtons,
       }: Params) =>
         // $FlowFixMe - `AbstractComponent` [1] is not an instance type.
         pickers[ANDROID_MODE.date].open({
@@ -68,10 +60,8 @@ function getOpenPicker(
           display,
           minimumDate,
           maximumDate,
-          neutralButtonLabel,
           timeZoneOffsetInMinutes,
-          positiveButtonLabel,
-          negativeButtonLabel,
+          dialogButtons,
         });
   }
 }
@@ -98,5 +88,15 @@ function validateAndroidProps(props: AndroidNativeProps) {
       !(display === ANDROID_DISPLAY.clock && mode === ANDROID_MODE.date),
     `display: ${display} and mode: ${mode} cannot be used together.`,
   );
+  if (
+    props?.positiveButtonLabel ||
+    props?.negativeButtonLabel ||
+    props?.neutralButtonLabel
+  ) {
+    console.warn(
+      'positiveButtonLabel, negativeButtonLabel and neutralButtonLabel are deprecated.' +
+        'Use positive / negative / neutralButton prop instead.',
+    );
+  }
 }
 export {getOpenPicker, timeZoneOffsetDateSetter, validateAndroidProps};

--- a/src/androidUtils.js
+++ b/src/androidUtils.js
@@ -7,8 +7,14 @@ import pickers from './picker';
 import type {AndroidNativeProps, DateTimePickerResult} from './types';
 import {sharedPropsValidation} from './utils';
 import invariant from 'invariant';
+import {processColor} from 'react-native';
 
 type Timestamp = number;
+
+type ProcessedButton = {
+  title: string,
+  textColor: $Call<typeof processColor>,
+};
 
 type Params = {
   value: Timestamp,
@@ -18,7 +24,11 @@ type Params = {
   maximumDate: AndroidNativeProps['maximumDate'],
   minuteInterval: AndroidNativeProps['minuteInterval'],
   timeZoneOffsetInMinutes: AndroidNativeProps['timeZoneOffsetInMinutes'],
-  dialogButtons: AndroidNativeProps['dialogButtons'],
+  dialogButtons: {
+    positive: ProcessedButton,
+    negative: ProcessedButton,
+    neutral: ProcessedButton,
+  },
 };
 
 export type PresentPickerCallback = (Params) => Promise<DateTimePickerResult>;
@@ -89,9 +99,9 @@ function validateAndroidProps(props: AndroidNativeProps) {
     `display: ${display} and mode: ${mode} cannot be used together.`,
   );
   if (
-    props?.positiveButtonLabel ||
-    props?.negativeButtonLabel ||
-    props?.neutralButtonLabel
+    props?.positiveButtonLabel !== undefined ||
+    props?.negativeButtonLabel !== undefined ||
+    props?.neutralButtonLabel !== undefined
   ) {
     console.warn(
       'positiveButtonLabel, negativeButtonLabel and neutralButtonLabel are deprecated.' +

--- a/src/datetimepicker.android.js
+++ b/src/datetimepicker.android.js
@@ -21,12 +21,15 @@ export default function RNDateTimePickerAndroid(
     is24Hour,
     minimumDate,
     maximumDate,
-    neutralButtonLabel,
     minuteInterval,
+    onError,
     timeZoneOffsetInMinutes,
+    positiveButton,
+    negativeButton,
+    neutralButton,
     positiveButtonLabel,
     negativeButtonLabel,
-    onError,
+    neutralButtonLabel,
   } = props;
   const valueTimestamp = value.getTime();
 
@@ -45,13 +48,16 @@ export default function RNDateTimePickerAndroid(
         is24Hour,
         minimumDate,
         maximumDate,
-        neutralButtonLabel,
         minuteInterval,
         timeZoneOffsetInMinutes,
-        positiveButtonLabel,
-        negativeButtonLabel,
         onError,
         onChange,
+        positiveButton,
+        negativeButton,
+        neutralButton,
+        positiveButtonLabel,
+        negativeButtonLabel,
+        neutralButtonLabel,
       };
       DateTimePickerAndroid.open(params);
     },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 import {FC, Ref, SyntheticEvent} from 'react';
-import {NativeMethods, ViewProps} from 'react-native';
+import {ColorValue, NativeMethods, ViewProps} from 'react-native';
 
 type IOSMode = 'date' | 'time' | 'datetime' | 'countdown';
 type AndroidMode = 'date' | 'time';
@@ -121,6 +121,8 @@ export type IOSNativeProps = Readonly<
   }
 >;
 
+export type ButtonType = {label?: string; textColor?: ColorValue};
+
 export type AndroidNativeProps = Readonly<
   BaseProps &
     DateOptions &
@@ -140,9 +142,23 @@ export type AndroidNativeProps = Readonly<
        */
       minuteInterval?: MinuteInterval;
 
-      positiveButtonLabel?: string;
+      positiveButton?: ButtonType;
+      neutralButton?: ButtonType;
+      negativeButton?: ButtonType;
+
+      /**
+       * @deprecated use neutralButton instead
+       * */
       neutralButtonLabel?: string;
+      /**
+       * @deprecated use positiveButton instead
+       * */
+      positiveButtonLabel?: string;
+      /**
+       * @deprecated use negativeButton instead
+       * */
       negativeButtonLabel?: string;
+
       /**
        * callback when an error occurs inside the date picker native code (such as null activity)
        */

--- a/src/types.js
+++ b/src/types.js
@@ -145,6 +145,8 @@ export type IOSNativeProps = $ReadOnly<{|
   enabled?: boolean,
 |}>;
 
+export type ButtonType = {label?: string, textColor?: ColorValue};
+
 export type AndroidNativeProps = $ReadOnly<{|
   ...BaseProps,
   ...DateOptions,
@@ -173,8 +175,20 @@ export type AndroidNativeProps = $ReadOnly<{|
    */
   minuteInterval?: MinuteInterval,
 
+  positiveButton?: ButtonType,
+  neutralButton?: ButtonType,
+  negativeButton?: ButtonType,
+  /**
+   * @deprecated use neutralButton instead
+   * */
   neutralButtonLabel?: string,
+  /**
+   * @deprecated use positiveButton instead
+   * */
   positiveButtonLabel?: string,
+  /**
+   * @deprecated use negativeButton instead
+   * */
   negativeButtonLabel?: string,
   onError?: (Error) => void,
 |}>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

follow up on https://github.com/react-native-datetimepicker/datetimepicker/pull/680 this PR allows setting button color dynamically from JS - android only

## Test Plan

tested locally 

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
