### PR TITLE
feat: support passing view props

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,13 @@ React Native date & time picker component for iOS, Android and Windows.
     - [`themeVariant` (`optional`, `iOS only`)](#themevariant-optional-ios-only)
     - [`locale` (`optional`, `iOS only`)](#locale-optional-ios-only)
     - [`is24Hour` (`optional`, `Windows and Android only`)](#is24hour-optional-windows-and-android-only)
-    - [`positiveButtonLabel` (`optional`, `Android only`)](#positiveButtonLabel-optional-android-only)
-    - [`negativeButtonLabel` (`optional`, `Android only`)](#negativeButtonLabel-optional-android-only)
-    - [`neutralButtonLabel` (`optional`, `Android only`)](#neutralbuttonlabel-optional-android-only)
+    - [`positiveButton` (`optional`, `Android only`)](#positiveButton-optional-android-only)
+    - [`negativeButton` (`optional`, `Android only`)](#negativeButton-optional-android-only)
+    - [`neutralButton` (`optional`, `Android only`)](#neutralButton-optional-android-only)
     - [`minuteInterval` (`optional`)](#minuteinterval-optional)
     - [`style` (`optional`, `iOS only`)](#style-optional-ios-only)
     - [`disabled` (`optional`, `iOS only`)](#disabled-optional-ios-only)
+    - [`view props` (`optional`, `iOS only`)](#view-props-optional-ios-only)
     - [`onError` (`optional`, `Android only`)](#onError-optional-android-only)
   - [Testing with Jest](#testing-with-jest)
   - [Migration from the older components](#migration-from-the-older-components)
@@ -448,7 +449,7 @@ Allows displaying neutral button on picker dialog.
 Pressing button can be observed in onChange handler as `event.type === 'neutralButtonPressed'`
 
 ```js
-<RNDateTimePicker neutralButton={{label: 'Clear', textColor: 'red'}} />
+<RNDateTimePicker neutralButton={{label: 'Clear', textColor: 'grey'}} />
 ```
 
 #### `negativeButton` (`optional`, `Android only`)
@@ -514,6 +515,10 @@ Alternatively, use the `themeVariant` prop.
 #### `disabled` (`optional`, `iOS only`)
 
 If true, the user won't be able to interact with the view.
+
+#### `View Props` (`optional`, `iOS only`)
+
+On iOS, you can pass any [View props](https://reactnative.dev/docs/view#props) to the component. Given that the underlying component is a native view, not all of them are guaranteed to be supported, but `testID` and `onLayout` are known to work.
 
 #### `onError` (`optional`, `Android only`)
 

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -48,8 +48,6 @@ export default function Picker({
   locale,
   maximumDate,
   minimumDate,
-  style,
-  testID,
   minuteInterval,
   timeZoneOffsetInMinutes,
   textColor,
@@ -59,6 +57,7 @@ export default function Picker({
   mode = IOS_MODE.date,
   display: providedDisplay = IOS_DISPLAY.default,
   disabled = false,
+  ...other
 }: IOSNativeProps): React.Node {
   sharedPropsValidation({value});
 
@@ -92,8 +91,7 @@ export default function Picker({
 
   return (
     <RNDateTimePicker
-      testID={testID}
-      style={style}
+      {...other}
       date={dateToMilliseconds(value)}
       locale={locale !== null && locale !== '' ? locale : undefined}
       maximumDate={dateToMilliseconds(maximumDate)}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -63,7 +63,7 @@ type TimeOptions = Readonly<
   }
 >;
 
-export type BaseProps = Readonly<ViewProps & DateOptions>;
+export type BaseProps = Readonly<Omit<ViewProps, 'children'> & DateOptions>;
 
 export type IOSNativeProps = Readonly<
   BaseProps & {

--- a/src/types.js
+++ b/src/types.js
@@ -6,7 +6,7 @@
 import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {ElementRef} from 'react';
+import type {ElementRef, Node} from 'react';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import {
   ANDROID_MODE,
@@ -84,8 +84,13 @@ type TimeOptions = $ReadOnly<{|
   is24Hour?: ?boolean,
 |}>;
 
+type ViewPropsWithoutChildren = $Diff<
+  ViewProps,
+  {children: ViewProps['children']},
+>;
+
 export type BaseProps = $ReadOnly<{|
-  ...ViewProps,
+  ...ViewPropsWithoutChildren,
   ...DateOptions,
 |}>;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

this adds support for `onLayout` and potentially other props which previously were not passed to the native component on ios.

## Test Plan

tested locally

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
