### PR TITLE
fix(android): keep selected date between min and max

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/KeepDateInRangeListener.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/KeepDateInRangeListener.java
@@ -1,0 +1,65 @@
+package com.reactcommunity.rndatetimepicker;
+
+import android.os.Bundle;
+import android.widget.DatePicker;
+
+import androidx.annotation.NonNull;
+
+import java.util.Calendar;
+
+// fix for https://issuetracker.google.com/issues/169602180
+// TODO revisit day, month, year with timezoneoffset fixes
+public class KeepDateInRangeListener implements DatePicker.OnDateChangedListener {
+
+  private final Bundle args;
+
+  public KeepDateInRangeListener(@NonNull Bundle args) {
+    this.args = args;
+  }
+
+  @Override
+  public void onDateChanged(DatePicker view, int year, int month, int day) {
+    fixPotentialMaxDateBug(view, year, month, day);
+    fixPotentialMinDateBug(view, year, month, day);
+  }
+
+  private void fixPotentialMaxDateBug(DatePicker datePicker, int year, int month, int day) {
+    if (!isDateAfterMaxDate(args, year, month, day)) {
+      return;
+    }
+    Calendar maxDate = Calendar.getInstance();
+    maxDate.setTimeInMillis(args.getLong(RNConstants.ARG_MAXDATE));
+    datePicker.updateDate(maxDate.get(Calendar.YEAR), maxDate.get(Calendar.MONTH), maxDate.get(Calendar.DAY_OF_MONTH));
+  }
+
+  private void fixPotentialMinDateBug(DatePicker datePicker, int year, int month, int day) {
+    if (!isDateBeforeMinDate(args, year, month, day)) {
+      return;
+    }
+    Calendar c = Calendar.getInstance();
+    c.setTimeInMillis(args.getLong(RNConstants.ARG_MINDATE));
+    datePicker.updateDate(c.get(Calendar.YEAR), c.get(Calendar.MONTH), c.get(Calendar.DAY_OF_MONTH));
+  }
+
+  public static boolean isDateAfterMaxDate(Bundle args, int year, int month, int day) {
+    if (!args.containsKey(RNConstants.ARG_MAXDATE)) {
+      return false;
+    }
+    Calendar maxDate = Calendar.getInstance();
+    maxDate.setTimeInMillis(args.getLong(RNConstants.ARG_MAXDATE));
+    return (year > maxDate.get(Calendar.YEAR) ||
+      (year == maxDate.get(Calendar.YEAR) && month > maxDate.get(Calendar.MONTH)) ||
+      (year == maxDate.get(Calendar.YEAR) && month == maxDate.get(Calendar.MONTH) && day > maxDate.get(Calendar.DAY_OF_MONTH)));
+  }
+
+  public static boolean isDateBeforeMinDate(Bundle args, int year, int month, int day) {
+    if (!args.containsKey(RNConstants.ARG_MINDATE)) {
+      return false;
+    }
+    Calendar minDate = Calendar.getInstance();
+    minDate.setTimeInMillis(args.getLong(RNConstants.ARG_MINDATE));
+    return (year < minDate.get(Calendar.YEAR) ||
+      (year == minDate.get(Calendar.YEAR) && month < minDate.get(Calendar.MONTH)) ||
+      (year == minDate.get(Calendar.YEAR) && month == minDate.get(Calendar.MONTH) && day < minDate.get(Calendar.DAY_OF_MONTH)));
+  }
+}

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
 import android.content.DialogInterface.OnClickListener;
+import android.os.Build;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -59,7 +60,6 @@ public class RNDatePickerDialogFragment extends DialogFragment {
           Bundle args,
           Context activityContext,
           @Nullable OnDateSetListener onDateSetListener) {
-
     final RNDate date = new RNDate(args);
     final int year = date.year();
     final int month = date.month();
@@ -137,6 +137,11 @@ public class RNDatePickerDialogFragment extends DialogFragment {
       c.set(Calendar.SECOND, 59);
       c.set(Calendar.MILLISECOND, 999);
       datePicker.setMaxDate(c.getTimeInMillis() - getOffset(c, timeZoneOffsetInMilliseconds));
+    }
+
+    if (args != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+      && (args.containsKey(RNConstants.ARG_MAXDATE) || args.containsKey(RNConstants.ARG_MINDATE))) {
+      datePicker.setOnDateChangedListener(new KeepDateInRangeListener(args));
     }
 
     return dialog;

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNTimePickerDialogModule.java
@@ -20,7 +20,6 @@ import android.os.Bundle;
 import android.widget.TimePicker;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
@@ -94,8 +93,7 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void open(@Nullable final ReadableMap options, final Promise promise) {
-
+  public void open(final ReadableMap options, final Promise promise) {
     FragmentActivity activity = (FragmentActivity) getCurrentActivity();
     if (activity == null) {
       promise.reject(
@@ -113,16 +111,14 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
         RNTimePickerDialogFragment oldFragment =
                 (RNTimePickerDialogFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);
 
-        if (oldFragment != null && options != null) {
+        if (oldFragment != null) {
           oldFragment.update(createFragmentArguments(options));
           return;
         }
 
         RNTimePickerDialogFragment fragment = new RNTimePickerDialogFragment();
 
-        if (options != null) {
-          fragment.setArguments(createFragmentArguments(options));
-        }
+        fragment.setArguments(createFragmentArguments(options));
 
         final TimePickerDialogListener listener = new TimePickerDialogListener(promise);
         fragment.setOnDismissListener(listener);

--- a/example/app.json
+++ b/example/app.json
@@ -1,7 +1,11 @@
 {
+  "$schema": "https://raw.githubusercontent.com/microsoft/react-native-test-app/trunk/schema.json",
   "name": "date-time-picker-example",
   "displayName": "date-time-picker-example",
   "singleApp": "date-time-picker-example",
+  "android": {
+    "package": "com.datetimepickerexample"
+  },
   "components": [
     {
       "appKey": "date-time-picker-example",

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -681,11 +681,11 @@ PODS:
     - React-jsi (= 0.70.0)
     - React-logger (= 0.70.0)
     - React-perflogger (= 0.70.0)
-  - ReactTestApp-DevSupport (1.6.13):
+  - ReactTestApp-DevSupport (1.6.19):
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNDateTimePicker (6.4.2):
+  - RNDateTimePicker (6.7.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -921,9 +921,9 @@ SPEC CHECKSUMS:
   React-rncore: 8858fe6b719170c20c197a8fd2dd53507bdae04b
   React-runtimeexecutor: 80c195ffcafb190f531fdc849dc2d19cb4bb2b34
   ReactCommon: de55f940495d7bf87b5d7bf55b5b15cdd50d7d7b
-  ReactTestApp-DevSupport: 8a8cff38c37cd8145a12ac7d7d0503dd08f97d65
+  ReactTestApp-DevSupport: dcff56cd656b2b47ac14e5908c03ce5d00a70004
   ReactTestApp-Resources: ff5f151e465e890010b417ce65ca6c5de6aeccbb
-  RNDateTimePicker: 0913d8322a3b21bb3d2010aca96c5090248223b6
+  RNDateTimePicker: 515431cd1a50a1fab054de40c7fc6a2cdd4803ab
   RNLocalize: cbcb55d0e19c78086ea4eea20e03fe8000bbbced
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 82c9e8f652789f67d98bed5aef9d6653f71b04a9


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

closes #561, but the same issue happens with minimumDate prop.

The issue actually comes from android implementation https://issuetracker.google.com/issues/169602180

## Test Plan

tested locally with this change to the example app:

```
  const [minimumDate, setMinimumDate] = useState(new Date('2020-12-20'));
  const [maximumDate, setMaximumDate] = useState(new Date('2023-01-20'));
```


### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

use the modified example, open android date picker modal, and select year 2020 / 2023 to see that the selected date is within the supplied range


## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
