### PR TITLE
Add testID support to android datepicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ If true, the user won't be able to interact with the view.
 
 #### `testID` (`optional`)
 
-Used to test your app with tools like e.g. detox.
+Usually used by app automation frameworks.
 Fully supported on iOS. On Android, only supported for `mode="date"`.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -517,9 +517,18 @@ Alternatively, use the `themeVariant` prop.
 
 If true, the user won't be able to interact with the view.
 
+#### `testID` (`optional`)
+
+Used to test your app with tools like e.g. detox.
+Fully supported on iOS. On Android, only supported for `mode="date"`.
+
+```js
+<RNDateTimePicker testID="datePicker" />
+```
+
 #### `View Props` (`optional`, `iOS only`)
 
-On iOS, you can pass any [View props](https://reactnative.dev/docs/view#props) to the component. Given that the underlying component is a native view, not all of them are guaranteed to be supported, but `testID` and `onLayout` are known to work.
+On iOS, you can pass any [View props](https://reactnative.dev/docs/view#props) to the component. Given that the underlying component is a native view, not all of them are guaranteed to be supported, but `onLayout` is known to work.
 
 #### `onError` (`optional`, `Android only`)
 

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Fully supported on iOS. On Android, only supported for `mode="date"`.
 
 #### `View Props` (`optional`, `iOS only`)
 
-On iOS, you can pass any [View props](https://reactnative.dev/docs/view#props) to the component. Given that the underlying component is a native view, not all of them are guaranteed to be supported, but `onLayout` is known to work.
+On iOS, you can pass any [View props](https://reactnative.dev/docs/view#props) to the component. Given that the underlying component is a native view, not all of them are guaranteed to be supported, but `testID` and `onLayout` are known to work.
 
 #### `onError` (`optional`, `Android only`)
 

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/DatePickerModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/DatePickerModule.java
@@ -135,6 +135,9 @@ public class DatePickerModule extends NativeModuleDatePickerSpec {
    *   <li>
    *      {@code display} To set the date picker display to 'calendar/spinner/default'
    *   </li>
+   *   <li>
+   *      {@code testID} testID for testing with e.g. detox.
+   *   </li>
    * </ul>
    *
    * @param promise This will be invoked with parameters action, year,
@@ -197,6 +200,9 @@ public class DatePickerModule extends NativeModuleDatePickerSpec {
     }
     if (options.hasKey(RNConstants.ARG_TZOFFSET_MINS) && !options.isNull(RNConstants.ARG_TZOFFSET_MINS)) {
       args.putLong(RNConstants.ARG_TZOFFSET_MINS, (long) options.getDouble(RNConstants.ARG_TZOFFSET_MINS));
+    }
+    if (options.hasKey(RNConstants.ARG_TESTID) && !options.isNull(RNConstants.ARG_TESTID)) {
+      args.putString(RNConstants.ARG_TESTID, options.getString(RNConstants.ARG_TESTID));
     }
     return args;
   }

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNConstants.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNConstants.java
@@ -12,6 +12,7 @@ public final class RNConstants {
   public static final String ARG_DISPLAY = "display";
   public static final String ARG_DIALOG_BUTTONS = "dialogButtons";
   public static final String ARG_TZOFFSET_MINS = "timeZoneOffsetInMinutes";
+  public static final String ARG_TESTID = "testID";
   public static final String ACTION_DATE_SET = "dateSetAction";
   public static final String ACTION_TIME_SET = "timeSetAction";
   public static final String ACTION_DISMISSED = "dismissedAction";

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
@@ -145,6 +145,10 @@ public class RNDatePickerDialogFragment extends DialogFragment {
       datePicker.setOnDateChangedListener(new KeepDateInRangeListener(args));
     }
 
+    if (args != null && args.containsKey(RNConstants.ARG_TESTID)) {
+      datePicker.setTag(args.getString(RNConstants.ARG_TESTID));
+    }
+
     return dialog;
   }
 

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -58,7 +58,7 @@ describe('e2e tests', () => {
   });
 
   it('nothing should happen if picker is dismissed / cancelled', async () => {
-    await userOpensPicker({mode: 'date', display: 'default'});
+    await userOpensPicker({mode: 'date', display: 'default', test});
 
     if (isIOS()) {
       await element(
@@ -71,11 +71,7 @@ describe('e2e tests', () => {
       await nextMonthArrow.tap();
       await userDismissesCompactDatePicker();
     } else {
-      const calendarHorizontalScrollView = element(
-        by
-          .type('android.widget.ScrollView')
-          .withAncestor(by.type('android.widget.DatePicker')),
-      );
+      const calendarHorizontalScrollView = getDatePickerAndroid();
       await calendarHorizontalScrollView.swipe('left', 'fast', 1);
       await calendarHorizontalScrollView.tap({x: 50, y: 200});
       await userTapsCancelButtonAndroid();

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -71,7 +71,11 @@ describe('e2e tests', () => {
       await nextMonthArrow.tap();
       await userDismissesCompactDatePicker();
     } else {
-      const calendarHorizontalScrollView = getDatePickerAndroid();
+      const calendarHorizontalScrollView = element(
+        by
+          .type('android.widget.ScrollView')
+          .withAncestor(by.id('dateTimePicker')),
+      );
       await calendarHorizontalScrollView.swipe('left', 'fast', 1);
       await calendarHorizontalScrollView.tap({x: 50, y: 200});
       await userTapsCancelButtonAndroid();

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -58,7 +58,7 @@ describe('e2e tests', () => {
   });
 
   it('nothing should happen if picker is dismissed / cancelled', async () => {
-    await userOpensPicker({mode: 'date', display: 'default', test});
+    await userOpensPicker({mode: 'date', display: 'default'});
 
     if (isIOS()) {
       await element(

--- a/example/e2e/utils/matchers.js
+++ b/example/e2e/utils/matchers.js
@@ -10,8 +10,7 @@ const getInlineTimePickerIOS = () => element(by.label('Time Picker'));
 
 const getDateTimePickerControlIOS = () => element(by.type('UIDatePicker'));
 
-const getDatePickerAndroid = () =>
-  element(by.type('android.widget.DatePicker'));
+const getDatePickerAndroid = () => element(by.id('dateTimePicker'));
 
 module.exports = {
   getTimeText,

--- a/src/DateTimePickerAndroid.android.js
+++ b/src/DateTimePickerAndroid.android.js
@@ -44,6 +44,7 @@ function open(props: AndroidNativeProps) {
     neutralButtonLabel,
     positiveButtonLabel,
     negativeButtonLabel,
+    testID,
   } = props;
   validateAndroidProps(props);
   invariant(originalValue, 'A date or time must be specified as `value` prop.');
@@ -84,6 +85,7 @@ function open(props: AndroidNativeProps) {
         minuteInterval,
         timeZoneOffsetInMinutes,
         dialogButtons,
+        testID,
       });
 
       switch (action) {

--- a/src/androidUtils.js
+++ b/src/androidUtils.js
@@ -24,6 +24,8 @@ type OpenParams = {
   maximumDate: AndroidNativeProps['maximumDate'],
   minuteInterval: AndroidNativeProps['minuteInterval'],
   timeZoneOffsetInMinutes: AndroidNativeProps['timeZoneOffsetInMinutes'],
+  timeZoneOffsetInMinutes: AndroidNativeProps['timeZoneOffsetInMinutes'],
+  testID: AndroidNativeProps['testID'],
   dialogButtons: {
     positive: ProcessedButton,
     negative: ProcessedButton,
@@ -64,6 +66,7 @@ function getOpenPicker(
         maximumDate,
         timeZoneOffsetInMinutes,
         dialogButtons,
+        testID,
       }: OpenParams) =>
         // $FlowFixMe - `AbstractComponent` [1] is not an instance type.
         pickers[ANDROID_MODE.date].open({
@@ -73,6 +76,7 @@ function getOpenPicker(
           maximumDate,
           timeZoneOffsetInMinutes,
           dialogButtons,
+          testID,
         });
   }
 }

--- a/src/androidUtils.js
+++ b/src/androidUtils.js
@@ -24,7 +24,6 @@ type OpenParams = {
   maximumDate: AndroidNativeProps['maximumDate'],
   minuteInterval: AndroidNativeProps['minuteInterval'],
   timeZoneOffsetInMinutes: AndroidNativeProps['timeZoneOffsetInMinutes'],
-  timeZoneOffsetInMinutes: AndroidNativeProps['timeZoneOffsetInMinutes'],
   testID: AndroidNativeProps['testID'],
   dialogButtons: {
     positive: ProcessedButton,

--- a/src/datepicker.android.js
+++ b/src/datepicker.android.js
@@ -21,6 +21,7 @@ export default class DatePickerAndroid {
    *   - `value` (`Date` object) - date to show by default
    *   - `minimumDate` (`Date` object) - minimum date that can be selected
    *   - `maximumDate` (`Date` object) - maximum date that can be selected
+   *   - `testID` (`string`) - testID for usage with e.g. detox
    *   - `display` (`enum('calendar', 'spinner', 'default')`) - To set the date-picker display to calendar/spinner/default
    *     - 'calendar': Show a date picker in calendar mode.
    *     - 'spinner': Show a date picker in spinner mode.

--- a/src/datepicker.android.js
+++ b/src/datepicker.android.js
@@ -21,7 +21,7 @@ export default class DatePickerAndroid {
    *   - `value` (`Date` object) - date to show by default
    *   - `minimumDate` (`Date` object) - minimum date that can be selected
    *   - `maximumDate` (`Date` object) - maximum date that can be selected
-   *   - `testID` (`string`) - testID for usage with e.g. detox
+   *   - `testID` (`string`) - Sets view tag for use with automation frameworks
    *   - `display` (`enum('calendar', 'spinner', 'default')`) - To set the date-picker display to calendar/spinner/default
    *     - 'calendar': Show a date picker in calendar mode.
    *     - 'spinner': Show a date picker in spinner mode.

--- a/src/datetimepicker.android.js
+++ b/src/datetimepicker.android.js
@@ -30,6 +30,7 @@ export default function RNDateTimePickerAndroid(
     positiveButtonLabel,
     negativeButtonLabel,
     neutralButtonLabel,
+    testID,
   } = props;
   const valueTimestamp = value.getTime();
 
@@ -58,6 +59,7 @@ export default function RNDateTimePickerAndroid(
         positiveButtonLabel,
         negativeButtonLabel,
         neutralButtonLabel,
+        testID,
       };
       DateTimePickerAndroid.open(params);
     },


### PR DESCRIPTION
# Summary
Makes testID prop work on Android as well.

This makes testing DatePickers with detox easier. Till now this was irrelevant, as detox did not support setting dates on datepickers on Android. 
I am currently working on a PR enabling this very functionality though: https://github.com/wix/Detox/pull/3790
Together with that PR it would be very useful having testID support for DatePickers on Android.

## Test Plan
The existing tests are sufficient. I only changed the matchers to not use the android className anymore, but the testID instead. This implicitely tests that the testID is working.

## Compatibility
| OS      | Implemented | when |
| ------- | :---------: | ---------------------- |
| iOS     |    ✅      | already implemented before |
| Android |    ✅      | implemented by this PR |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on ~~a device and~~ a simulator
- [x]  I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow) to the best of my abbillity. Please check whether I did it proper way.
- [x] ~~I added a sample use of the API in the example project (`example/App.js`)~~ Already covered by existing example app.
- [x] I have added automated tests, either in JS or e2e tests, as applicable. I slightly adjusted the e2e tests to cover this feature.
