### PR TITLE
Renaming the project name from DateTimePickerWindows to DateTimePicker

### DIFF
--- a/windows/DateTimePickerWindows/DateTimePickerWindows.vcxproj
+++ b/windows/DateTimePickerWindows/DateTimePickerWindows.vcxproj
@@ -7,7 +7,7 @@
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
     <ProjectGuid>{0986a4db-8e72-4bb7-ae32-7d9df1758a9d}</ProjectGuid>
-    <ProjectName>DateTimePickerWindows</ProjectName>
+    <ProjectName>DateTimePicker</ProjectName>
     <RootNamespace>DateTimePicker</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>


### PR DESCRIPTION
# Summary
On Windows 11, react-native-windows version 0.68.2 we get a runtime error when trying to use the DateTimePicker after following the manual setup instructions outlined in the repo.

The error occurs when we try to create a new instance of winrt::DateTimePicker::ReactPackageProvider in our App class. The error code is REGDB_E_CLASSNOTREG error, which happens after calling RoGetActivationFactory for the winrt class name DateTimePicker.ReactPackageProvider.

This happens because the winrt class namespace does not match the DLL name. The DateTimePickerWindows project/dll needs to be renamed to just DateTimePicker. 

This PR closes #635 
## Test Plan

I have tested this with local modifications to the vcxproj.
With this change, following the manual setup instructions outlined in the repo the date time picker works as expected.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅ ❌     |
| Android |    ✅ ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
