### PR TITLE
Add override props

### DIFF
--- a/windows/DateTimePickerWindows/DateTimePickerWindows.vcxproj
+++ b/windows/DateTimePickerWindows/DateTimePickerWindows.vcxproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
   <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200316.3\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>

--- a/windows/DateTimePickerWindows/DateTimePickerWindows.vcxproj
+++ b/windows/DateTimePickerWindows/DateTimePickerWindows.vcxproj
@@ -7,7 +7,7 @@
     <CppWinRTGenerateWindowsMetadata>true</CppWinRTGenerateWindowsMetadata>
     <MinimalCoreWin>true</MinimalCoreWin>
     <ProjectGuid>{0986a4db-8e72-4bb7-ae32-7d9df1758a9d}</ProjectGuid>
-    <ProjectName>DateTimePickerWindows</ProjectName>
+    <ProjectName>DateTimePicker</ProjectName>
     <RootNamespace>DateTimePicker</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>


### PR DESCRIPTION
# Summary


On windows 11, DateTimePicker vcxproj defaults the WindowsTargetVersion to 10.0.18382 if no WindowsTargetVersion is specified. We are not able override it with a particular WindowsTargetVersion we are currently using in the parent project (where we use the DateTimePicker as a npm dependency).

This PR solves https://github.com/react-native-datetimepicker/datetimepicker/issues/713

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅ ❌     |
| Android |    ✅ ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
