### PR TITLE
fix error of adding final before context in setButtonTextColor method  in Common.java android

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java
@@ -62,7 +62,7 @@ public class Common {
 	}
 
 	@NonNull
-	public static DialogInterface.OnShowListener setButtonTextColor(@NonNull Context activityContext, final AlertDialog dialog, final Bundle args, final boolean needsColorOverride) {
+	public static DialogInterface.OnShowListener setButtonTextColor(@NonNull final Context activityContext, final AlertDialog dialog, final Bundle args, final boolean needsColorOverride) {
     return new DialogInterface.OnShowListener() {
       @Override
       public void onShow(DialogInterface dialogInterface) {


### PR DESCRIPTION
Summary
The Fix is required in the common.java file.
After installing the following error occurs in android while running the application:

> 
> > Task :react-native-community_datetimepicker:compileDebugJavaWithJavac FAILED
> 168 actionable tasks: 161 executed, 7 up-to-date
> Warning: Mapping new ns http://schemas.android.com/repository/android/common/02 to old ns http://schemas.android.com/repository/android/common/01
> Warning: Mapping new ns http://schemas.android.com/repository/android/generic/02 to old ns http://schemas.android.com/repository/android/generic/01
> Warning: Mapping new ns http://schemas.android.com/sdk/android/repo/addon2/02 to old ns http://schemas.android.com/sdk/android/repo/addon2/01
> Warning: Mapping new ns http://schemas.android.com/sdk/android/repo/repository2/02 to old ns http://schemas.android.com/sdk/android/repo/repository2/01
> Warning: Mapping new ns http://schemas.android.com/sdk/android/repo/sys-img2/02 to old ns http://schemas.android.com/sdk/android/repo/sys-img2/01
> Note: /Users/developer/Documents/PersonalProjects/projectName-/node_modules/lottie-react-native/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java uses or overrides a deprecated API.
> Note: Recompile with -Xlint:deprecation for details.
> Note: /Users/developer/Documents/PersonalProjects/projectName-/node_modules/lottie-react-native/src/android/src/main/java/com/airbnb/android/react/lottie/LottieAnimationViewManager.java uses unchecked or unsafe operations.
> Note: Recompile with -Xlint:unchecked for details.
> /Users/developer/Documents/PersonalProjects/projectName-/node_modules/@react-native-community/datetimepicker/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java:76: error: local variable activityContext is accessed from within inner class; needs to be declared final
>         int textColorPrimary = getDefaultDialogButtonTextColor(activityContext);
>                                                                ^
> Note: Some input files use or override a deprecated API.
> Note: Recompile with -Xlint:deprecation for details.
> 1 error

So I fixed the error by adding "final" in the method and attach the PR.

