### PR TITLE
fix(android): gradle 8 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,19 +62,6 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
 }
 
-project.afterEvaluate {
-    def packageDebugResources = project.tasks.findByName('react-native-community_datetimepicker:packageDebugResources')
-    def compileDebugRenderscript = project.tasks.findByName('compileDebugRenderscript')
-    def generateDebugResValues = project.tasks.findByName('generateDebugResValues')
-
-    if (packageDebugResources != null && compileDebugRenderscript != null && generateDebugResValues != null) {
-        packageDebugResources.dependsOn compileDebugRenderscript, generateDebugResValues
-    }
-    
-    def compileDebugJavaWithJavac = project.tasks.findByName('compileDebugJavaWithJavac')
-    def compileDebugAidl = project.tasks.findByName('compileDebugAidl')
-
-    if (compileDebugJavaWithJavac != null && compileDebugAidl != null) {
-        compileDebugJavaWithJavac.dependsOn compileDebugAidl
-    }
+project.tasks.findByName('compileDebugJavaWithJavac').configure { compileDebugJavaWithJavac ->
+    compileDebugJavaWithJavac.dependsOn project.tasks.findByName('compileDebugAidl')
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,3 +61,20 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
 }
+
+project.afterEvaluate {
+    def packageDebugResources = project.tasks.findByName('react-native-community_datetimepicker:packageDebugResources')
+    def compileDebugRenderscript = project.tasks.findByName('compileDebugRenderscript')
+    def generateDebugResValues = project.tasks.findByName('generateDebugResValues')
+
+    if (packageDebugResources != null && compileDebugRenderscript != null && generateDebugResValues != null) {
+        packageDebugResources.dependsOn compileDebugRenderscript, generateDebugResValues
+    }
+    
+    def compileDebugJavaWithJavac = project.tasks.findByName('compileDebugJavaWithJavac')
+    def compileDebugAidl = project.tasks.findByName('compileDebugAidl')
+
+    if (compileDebugJavaWithJavac != null && compileDebugAidl != null) {
+        compileDebugJavaWithJavac.dependsOn compileDebugAidl
+    }
+}


### PR DESCRIPTION
fixes react-native-datetimepicker#783 React native 72 upgrades gradle from 7 to 8. This patch resolved the following issue:
```
Reason: Task ':@react-native-community_datetimepicker:compileDebugJavaWithJavac' uses this output of task ':react-native-community_datetimepicker:compileDebugAidl' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
```

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Upgrading my project from RN 71 -> 72 (gradle 8) caused a build failure from this datetimepicker dependency. I was able to fix the build failure by adding a patch to `node_modules/@react-native-community/datetimepicker/android/build.gradle`.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

Build for android on react native 72 & gradle 8

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
