### PR TITLE
fix: use RNC prefix for android modules

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/DatePickerModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/DatePickerModule.java
@@ -35,7 +35,7 @@ import java.util.Calendar;
 public class DatePickerModule extends NativeModuleDatePickerSpec {
 
   @VisibleForTesting
-  public static final String NAME = "RNDatePicker";
+  public static final String NAME = "RNCDatePicker";
 
   public DatePickerModule(ReactApplicationContext reactContext) {
     super(reactContext);

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/TimePickerModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/TimePickerModule.java
@@ -33,7 +33,7 @@ import static com.reactcommunity.rndatetimepicker.Common.dismissDialog;
 public class TimePickerModule extends NativeModuleTimePickerSpec {
 
   @VisibleForTesting
-  public static final String NAME = "RNTimePicker";
+  public static final String NAME = "RNCTimePicker";
 
   public TimePickerModule(ReactApplicationContext reactContext) {
     super(reactContext);

--- a/src/specs/NativeModuleDatePicker.js
+++ b/src/specs/NativeModuleDatePicker.js
@@ -12,4 +12,4 @@ export interface Spec extends TurboModule {
   open(params: OpenParams): Promise<DateTimePickerResult>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('RNDatePicker'): ?Spec);
+export default (TurboModuleRegistry.getEnforcing<Spec>('RNCDatePicker'): ?Spec);

--- a/src/specs/NativeModuleTimePicker.js
+++ b/src/specs/NativeModuleTimePicker.js
@@ -13,4 +13,4 @@ export interface Spec extends TurboModule {
   open(params: OpenParams): Promise<DateTimePickerResult>;
 }
 
-export default (TurboModuleRegistry.getEnforcing<Spec>('RNTimePicker'): ?Spec);
+export default (TurboModuleRegistry.getEnforcing<Spec>('RNCTimePicker'): ?Spec);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
Fixes [767](https://github.com/react-native-datetimepicker/datetimepicker/issues/767) for context. In the past, the android date module was registered under  `RNDatePickerAndroid`. But when this package was updated to support the new arch, the module name was changed to be registered under `RNDatePicker`. The problem is that there is another popular package called [`react-native-date-picker` ](https://github.com/henninghall/react-native-date-picker), which was already registering its android module under `RNDatePicker`. Due to the change mentioned earlier, app that used to depend on both packages now are having a conflict as shown in the linked issue.

This pr basically changes the android module registration names to have an `RNC` prefix to align with other react native community packages and to resolve the conflict with the other package

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
