### PR TITLE
fix import deprecated

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -5,7 +5,7 @@
 
 import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 import type {HostComponent} from 'react-native';
-import type { ViewPropTypes as ViewProps } from 'deprecated-react-native-prop-types';
+import type {ViewPropTypes as ViewProps} from 'deprecated-react-native-prop-types';
 import type {ElementRef, Node} from 'react';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import {

--- a/src/types.js
+++ b/src/types.js
@@ -5,7 +5,7 @@
 
 import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 import type {HostComponent} from 'react-native';
-import type {ViewPropTypes as ViewProps} from 'deprecated-react-native-prop-types';
+import {ViewPropTypes as ViewProps} from 'deprecated-react-native-prop-types';
 import type {ElementRef, Node} from 'react';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import {

--- a/src/types.js
+++ b/src/types.js
@@ -5,7 +5,7 @@
 
 import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 import type {HostComponent} from 'react-native';
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
+import type { ViewPropTypes as ViewProps } from 'deprecated-react-native-prop-types';
 import type {ElementRef, Node} from 'react';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import {


### PR DESCRIPTION
use:

 import type { ViewPropTypes as ViewProps } from 'deprecated-react-native-prop-types';
