### PR TITLE
Add missing countdown in RCT_ENUM_CONVERTE

### DIFF
--- a/ios/RNDateTimePickerManager.m
+++ b/ios/RNDateTimePickerManager.m
@@ -25,6 +25,7 @@ RCT_ENUM_CONVERTER(UIDatePickerMode, (@{
   @"time": @(UIDatePickerModeTime),
   @"date": @(UIDatePickerModeDate),
   @"datetime": @(UIDatePickerModeDateAndTime),
+  @"countdown": @(UIDatePickerModeCountDownTimer),
 }), UIDatePickerModeTime, integerValue)
 
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
After upgrading react native to `0.72.3` the countdown mode stopped working and was fallback to time mode. My guess is that react native changed how `RCT_ENUM_CONVERTER` works.
Adding `countdown` to the enum fixed the issue.

## Test Plan
Try passing countdown to mode prop 

| Before | After the fix |
|--------|--------|
| <img width="500px" src="https://github.com/react-native-datetimepicker/datetimepicker/assets/18466484/3ca5928a-21d2-41c6-b5fa-0d6413a243f9" /> | <img width="500px" src="https://github.com/react-native-datetimepicker/datetimepicker/assets/18466484/09b2bac8-4814-44c2-88cf-9b64baa1cb55" /> | 





### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
