### PR TITLE
Fix crash when attempting to show picker in different mode/style

### DIFF
--- a/ios/RNDateTimePickerShadowView.m
+++ b/ios/RNDateTimePickerShadowView.m
@@ -47,6 +47,12 @@ static YGSize RNDateTimePickerShadowViewMeasure(YGNodeRef node, float width, YGM
 
   __block CGSize size;
   dispatch_sync(dispatch_get_main_queue(), ^{
+    if (@available(iOS 13.4, *)) {
+      // if this is not reset to the default before setting style it can result in a crash
+      // use case: picker was first shown with mode UIDatePickerModeCountDownTimer then
+      [shadowPickerView.picker setDatePickerMode:UIDatePickerModeDateAndTime];
+      [shadowPickerView.picker setPreferredDatePickerStyle:shadowPickerView.displayIOS];
+    }
     [shadowPickerView.picker setDate:shadowPickerView.date];
     [shadowPickerView.picker setDatePickerMode:shadowPickerView.mode];
     [shadowPickerView.picker setLocale:shadowPickerView.locale];


### PR DESCRIPTION
# Summary

After displaying a picker the first time in an app. The second time displaying if using countDownTimer may cause a crash depending on the picker state. Resetting the picker state before setting mode and style fixes the issue.

Stack trace:
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'UIDatePickerMode .countDownTimer is unsupported when using style .inline.' *** First throw call stack: ( 0   CoreFoundation                      0x00000001804658a8 __exceptionPreprocess + 172 1   libobjc.A.dylib                     0x000000018005c09c objc_exception_throw + 56 2   Foundation                          0x0000000180cf3b90 -[NSMutableDictionary(NSMutableDictionary) classForCoder] + 0 3   UIKitCore                           0x000000011c2e3728 _UIDatePickerClassForStyleAndMode + 460 4   UIKitCore                           0x000000011c2e4010 -[UIDatePicker _updatePickerViewIfNecessary] + 60 5   UIKitCore                           0x000000011c2e440c -[UIDatePicker setDatePickerMode:] + 68 6   <redacted>                           0x0000000100ca4e88 -[RNDateTimePicker setDatePickerMode:] + 64 7   <redacted>                           0x0000000100ca70a0 __RNDateTimePickerShadowViewMeasure_block_invoke <…>


* How did you implement the solution?
Currently this change is applied for us in a yarn patch 

* What areas of the library does it impact?
  Only iOS UIDatePicker related

### What are the steps to reproduce (after prerequisites)?
In our app a picker is shown with UIDatePickerMode that is not UIDatePickerModeCountDownTimer. Then attempting to display a picker else where in the app with the UIDatePickerModeCountDownTimer crashes the app.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| Android |     ❌     |

## Checklist

- [ x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
