### PR TITLE
Fix incorrect UIDatePicker size computation when UIDatePickerModeDateAndTime + UIDatePickerStyleInline

### DIFF
--- a/ios/RNDateTimePickerShadowView.m
+++ b/ios/RNDateTimePickerShadowView.m
@@ -70,6 +70,15 @@ static YGSize RNDateTimePickerShadowViewMeasure(YGNodeRef node, float width, YGM
 
     size = [shadowPickerView.picker sizeThatFits:UILayoutFittingCompressedSize];
     size.width += 10;
+    if (@available(iOS 14.0, *)) {
+      if(shadowPickerView.picker.datePickerMode == UIDatePickerModeDateAndTime
+         && shadowPickerView.picker.datePickerStyle == UIDatePickerStyleInline) {
+        // fixes calculation bug in iOS component when mode is DateAndTime and style is Inline
+        // the sizing seems to not include the bottom time control at all which should have a
+        // standard row size of 44
+        size.height += 44;
+      }
+   }
   });
 
   return (YGSize){


### PR DESCRIPTION
# Summary

Fix issue where UIDatePicker sizeThatFits: doesn't account for the bottom 44 height of the time picker row when configured with datePickerMode == UIDatePickerModeDateAndTime and datePickerStyle == UIDatePickerStyleInline. There are a few examples online of others running into this where wrapping in a parent view and configuring autolayout to the parent anchors fixes the issue but that did not seem like a proper fix for how UIDatePicker is used here. I've isolated this change ONLY to this use case as other calls to get size appear correct.

* What areas of the library does it impact?

This impacts the size calculation which is provided to react.

## Test Plan
Pre-fix: ![IMG_2333](https://github.com/react-native-datetimepicker/datetimepicker/assets/148379097/69e2ed58-3717-4fd7-8794-1967f06bb275)

Post-fix: ![CleanShot 2023-10-18 at 23 13 33@2x](https://github.com/react-native-datetimepicker/datetimepicker/assets/148379097/b668663c-d143-4a7c-95fa-85deb662519a)

Debugging the size's height would always come out to about 348 when it should be closer to 392 in order to account for the bottom time selection row

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| Android |    ❌     |

## Checklist

- [x] I have tested this on a device and a simulator
