### PR TITLE
Fix a broken link inside CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ yarn test
 
 Detox is a gray box end-to-end testing and automation library for mobile apps.
 
-- [Dependencies required](https://github.com/wix/Detox/blob/master/docs/Introduction.GettingStarted.md#step-1-install-dependencies)
+- [Dependencies required](https://wix.github.io/Detox/docs/introduction/getting-started/#detox-prerequisites)
 
 For cleaning all the detox builds just run `npm run detox:clean`.
 


### PR DESCRIPTION
# Summary

Update the old link inside CONTRIBUTING.md > Detox > Dependencies required.
The link : https://github.com/wix/Detox/blob/master/docs/Introduction.GettingStarted.md#step-1-install-dependencies returns a 404. They changed their docs from the github repo to wix.github.io

## Test Plan

### What's required for testing (prerequisites)?

a mouse to click on the old link ?

### What are the steps to reproduce (after prerequisites)?

click on the old link -> 404
click on the new link -> get the needed informations to install Detox

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| Android |    ✅      |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
