### PR TITLE
chore: add real device testing note

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,8 @@ Please see [manual-installation.md](/docs/manual-installation.md)
 5. Run `yarn run start:ios` or `yarn run start:android` or `yarn run start:windows`
 6. To do any development on the library, open the example project (in the `example` folder) in xCode or Android Studio. The example project depends on the library code, which you can edit and observe any changes in the example project.
 
+This project is tested with BrowserStack.
+
 [circle-ci-badge]: https://img.shields.io/circleci/project/github/react-native-community/datetimepicker/master.svg?style=flat-square
 [circle-ci-status]: https://circleci.com/gh/react-native-datetimepicker/datetimepicker.svg?style=svg
 [support-badge]: https://img.shields.io/badge/platforms-android%20%7C%20ios%20%7C%20windows-lightgrey.svg?style=flat-square


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Picking dates (especially with Android's device variability) can be tricky and I'd like to be able to test things out on real devices so that I can catch more corner cases and have more confidence in the output. Browserstack can provide that.

