### PR TITLE
chore: support Fabric on react-native 73.0 (#865)

### DIFF
--- a/ios/fabric/cpp/react/renderer/components/RNDateTimePicker/ComponentDescriptors.h
+++ b/ios/fabric/cpp/react/renderer/components/RNDateTimePicker/ComponentDescriptors.h
@@ -18,20 +18,20 @@ class RNDateTimePickerComponentDescriptor final : public ConcreteComponentDescri
   public:
     using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
 
-    void adopt(ShadowNode::Unshared const &shadowNode) const override {
-      react_native_assert(std::dynamic_pointer_cast<RNDateTimePickerShadowNode>(shadowNode));
-      auto pickerShadowNode = std::static_pointer_cast<RNDateTimePickerShadowNode>(shadowNode);
+    void adopt(ShadowNode& shadowNode) const override {
+      react_native_assert(dynamic_cast<RNDateTimePickerShadowNode*>(&shadowNode));
+      auto& pickerShadowNode = static_cast<RNDateTimePickerShadowNode&>(shadowNode);
 
       react_native_assert(
-        std::dynamic_pointer_cast<YogaLayoutableShadowNode>(pickerShadowNode));
-      auto layoutableShadowNode =
-        std::static_pointer_cast<YogaLayoutableShadowNode>(pickerShadowNode);
+        dynamic_cast<YogaLayoutableShadowNode*>(&pickerShadowNode));
+      auto& layoutableShadowNode =
+        static_cast<YogaLayoutableShadowNode&>(pickerShadowNode);
 
-      auto state = std::static_pointer_cast<const RNDateTimePickerShadowNode::ConcreteState>(shadowNode->getState());
+      auto state = std::static_pointer_cast<const RNDateTimePickerShadowNode::ConcreteState>(shadowNode.getState());
       auto stateData = state->getData();
         
       if(stateData.frameSize.width != 0 && stateData.frameSize.height != 0) {
-        layoutableShadowNode->setSize(Size{stateData.frameSize.width, stateData.frameSize.height});
+        layoutableShadowNode.setSize(Size{stateData.frameSize.width, stateData.frameSize.height});
       }
 
       ConcreteComponentDescriptor::adopt(shadowNode);


### PR DESCRIPTION
## Description

Adding library support for RN 0.73 (fabric renderer).

# Summary

The signature of the "adopt" function changed in RN 0.73. This fix building on react-native 0.73.

## Test Plan

Nothing special, just build the project

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
