### PR TITLE
Add visionOS support in podspec

### DIFF
--- a/RNDateTimePicker.podspec
+++ b/RNDateTimePicker.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package['license']
   s.author       = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, "11.0"
+  s.platforms = { :ios => "11.0", :visionos => "1.0" }
   s.source       = { :git => "https://github.com/react-native-community/datetimepicker", :tag => "v#{s.version}" }
   s.source_files = "ios/**/*.{h,m,mm,cpp}"
   s.requires_arc = true


### PR DESCRIPTION


# Summary

Split out from #879 , this _just_ updates the podspec without updating the test app and repo to yarn 4. 

## Test Plan

CI should pass.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| visionOS     |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
