### PR TITLE
Fix: new arch support for 0.74

### DIFF
--- a/ios/fabric/cpp/react/renderer/components/RNDateTimePicker/ComponentDescriptors.h
+++ b/ios/fabric/cpp/react/renderer/components/RNDateTimePicker/ComponentDescriptors.h
@@ -18,24 +18,19 @@ class RNDateTimePickerComponentDescriptor final : public ConcreteComponentDescri
   public:
     using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
 
-    void adopt(ShadowNode::Unshared const &shadowNode) const override {
-      react_native_assert(std::dynamic_pointer_cast<RNDateTimePickerShadowNode>(shadowNode));
-      auto pickerShadowNode = std::static_pointer_cast<RNDateTimePickerShadowNode>(shadowNode);
+  void adopt(ShadowNode& shadowNode) const override {
+    auto& pickerShadowNode = static_cast<RNDateTimePickerShadowNode&>(shadowNode);
+    auto& layoutableShadowNode = static_cast<YogaLayoutableShadowNode&>(pickerShadowNode);
 
-      react_native_assert(
-        std::dynamic_pointer_cast<YogaLayoutableShadowNode>(pickerShadowNode));
-      auto layoutableShadowNode =
-        std::static_pointer_cast<YogaLayoutableShadowNode>(pickerShadowNode);
+    auto state = std::static_pointer_cast<const RNDateTimePickerShadowNode::ConcreteState>(shadowNode.getState());
+    auto stateData = state->getData();
 
-      auto state = std::static_pointer_cast<const RNDateTimePickerShadowNode::ConcreteState>(shadowNode->getState());
-      auto stateData = state->getData();
-        
-      if(stateData.frameSize.width != 0 && stateData.frameSize.height != 0) {
-        layoutableShadowNode->setSize(Size{stateData.frameSize.width, stateData.frameSize.height});
-      }
-
-      ConcreteComponentDescriptor::adopt(shadowNode);
+    if(stateData.frameSize.width != 0 && stateData.frameSize.height != 0) {
+      layoutableShadowNode.setSize(Size{stateData.frameSize.width, stateData.frameSize.height});
     }
+
+    ConcreteComponentDescriptor::adopt(shadowNode);
+  }
 };
 
 } // namespace react

--- a/ios/fabric/cpp/react/renderer/components/RNDateTimePicker/ComponentDescriptors.h
+++ b/ios/fabric/cpp/react/renderer/components/RNDateTimePicker/ComponentDescriptors.h
@@ -18,19 +18,19 @@ class RNDateTimePickerComponentDescriptor final : public ConcreteComponentDescri
   public:
     using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
 
-  void adopt(ShadowNode& shadowNode) const override {
-    auto& pickerShadowNode = static_cast<RNDateTimePickerShadowNode&>(shadowNode);
-    auto& layoutableShadowNode = static_cast<YogaLayoutableShadowNode&>(pickerShadowNode);
+    void adopt(ShadowNode& shadowNode) const override {
+      auto& pickerShadowNode = static_cast<RNDateTimePickerShadowNode&>(shadowNode);
+      auto& layoutableShadowNode = static_cast<YogaLayoutableShadowNode&>(pickerShadowNode);
 
-    auto state = std::static_pointer_cast<const RNDateTimePickerShadowNode::ConcreteState>(shadowNode.getState());
-    auto stateData = state->getData();
+      auto state = std::static_pointer_cast<const RNDateTimePickerShadowNode::ConcreteState>(shadowNode.getState());
+      auto stateData = state->getData();
 
-    if(stateData.frameSize.width != 0 && stateData.frameSize.height != 0) {
-      layoutableShadowNode.setSize(Size{stateData.frameSize.width, stateData.frameSize.height});
+      if(stateData.frameSize.width != 0 && stateData.frameSize.height != 0) {
+        layoutableShadowNode.setSize(Size{stateData.frameSize.width, stateData.frameSize.height});
+      }
+
+      ConcreteComponentDescriptor::adopt(shadowNode);
     }
-
-    ConcreteComponentDescriptor::adopt(shadowNode);
-  }
 };
 
 } // namespace react


### PR DESCRIPTION
# Summary
The signature for `ComponentDescriptor::adopt` was changed [here](https://github.com/facebook/react-native/pull/39354). Currently the library will only build on RN 0.72. These changes will not support 0.72 because a pick was missed. I spoke to Riccardo and this will be backported soon

## Test Plan
Tested in our (Expos) sample app. The app builds successfully and the library works as expected. 

### What's required for testing (prerequisites)?
A RN 0.74 project, new arch, bridgeless.

### What are the steps to reproduce (after prerequisites)?

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
