### PR TITLE
Added React Native version support table README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Check the `react-native` version support table below to find the corrosponding `
 | react-native version |  version |
 | -------------------- | -------- |
 |      0.73.0+         |  7.6.3+  |
-|      <=0.72          | <=7.6.2  |
+|      <=0.72.0        | <=7.6.2  |
 |      0.7.0+          |  7.0.1+  |
 |      <0.7.0          | <=7.0.0  |
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ React Native date & time picker component for iOS, Android and Windows (please n
   - [Expo users notice](#expo-users-notice)
   - [Getting started](#getting-started)
   - [Usage](#usage)
+  - [React Native Support](#react-native-support)
   - [Localization note](#localization-note)
   - [Android imperative API](#android-imperative-api)
   - [Props / params](#component-props--params-of-the-android-imperative-api)
@@ -141,6 +142,17 @@ Autolinking is not yet implemented on Windows, so [manual installation ](/docs/m
 #### RN >= 0.60
 
 If you are using RN >= 0.60, only run `npx pod-install`. Then rebuild your project.
+
+## React Native Support
+Check the `react-native` version support table below to find the corrosponding `datetimepicker` version to meet support requirements.
+
+| react-native version |  version |
+| -------------------- | -------- |
+|      0.73.0+         |  7.6.3+  |
+|      <=0.72          | <=7.6.2  |
+|      0.7.0+          |  7.0.1+  |
+|      <0.7.0          | <=7.0.0  |
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Check the `react-native` version support table below to find the corrosponding `
 |      0.73.0+         |  7.6.3+  |
 |    <=0.72.0          | <=7.6.2  |
 |      0.70.0+         |  7.0.1+  |
-|      <0.7.0          | <=7.0.0  |
+|      <0.70.0         | <=7.0.0  |
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Check the `react-native` version support table below to find the corrosponding `
 |      0.73.0+         |  7.6.3+  |
 |    <=0.72.0          | <=7.6.2  |
 |      0.70.0+         |  7.0.1+  |
-|      <0.70.0         | <=7.0.0  |
+|     <0.70.0          | <=7.0.0  |
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ Check the `react-native` version support table below to find the corrosponding `
 | react-native version |  version |
 | -------------------- | -------- |
 |      0.73.0+         |  7.6.3+  |
-|      <=0.72.0        | <=7.6.2  |
-|      0.7.0+          |  7.0.1+  |
+|    <=0.72.0          | <=7.6.2  |
+|      0.70.0+         |  7.0.1+  |
 |      <0.7.0          | <=7.0.0  |
 
 


### PR DESCRIPTION


# Summary
I ran into build issues when installing this via storybook. It was unclear that the latest version of `datetimepicker` was not supported with older versions of react-native. I spent a while figuring this out though other issues and it would be good to include a version support table in the readme so others don't have to figure out backwards compatibility issues



## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
