### PR TITLE
feat: Add set first day week android

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,15 +144,15 @@ Autolinking is not yet implemented on Windows, so [manual installation ](/docs/m
 If you are using RN >= 0.60, only run `npx pod-install`. Then rebuild your project.
 
 ## React Native Support
+
 Check the `react-native` version support table below to find the corrosponding `datetimepicker` version to meet support requirements.
 
-| react-native version |  version |
-| -------------------- | -------- |
-|      0.73.0+         |  7.6.3+  |
-|    <=0.72.0          | <=7.6.2  |
-|      0.70.0+         |  7.0.1+  |
-|     <0.70.0          | <=7.0.0  |
-
+| react-native version | version |
+| -------------------- | ------- |
+| 0.73.0+              | 7.6.3+  |
+| <=0.72.0             | <=7.6.2 |
+| 0.70.0+              | 7.0.1+  |
+| <0.70.0              | <=7.0.0 |
 
 ## Usage
 
@@ -424,7 +424,7 @@ Reference: https://docs.microsoft.com/en-us/uwp/api/windows.globalization.dateti
 <RNDateTimePicker dateFormat="dayofweek day month" />
 ```
 
-#### `firstDayOfWeek` (`optional`, `Windows only`)
+#### `firstDayOfWeek` (`optional`, `Android and Windows only`)
 
 Indicates which day is shown as the first day of the week.
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ If you are using RN >= 0.60, only run `npx pod-install`. Then rebuild your proje
 
 ## React Native Support
 
-Check the `react-native` version support table below to find the corrosponding `datetimepicker` version to meet support requirements.
+Check the `react-native` version support table below to find the corresponding `datetimepicker` version to meet support requirements.
 
 | react-native version | version |
 | -------------------- | ------- |

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/DatePickerModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/DatePickerModule.java
@@ -5,185 +5,191 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.reactcommunity.rndatetimepicker;
+ package com.reactcommunity.rndatetimepicker;
 
-import android.app.DatePickerDialog.OnDateSetListener;
-import android.content.DialogInterface;
-import android.content.DialogInterface.OnDismissListener;
-import android.content.DialogInterface.OnClickListener;
-import android.os.Bundle;
-import android.widget.DatePicker;
-import androidx.annotation.NonNull;
-import androidx.fragment.app.FragmentActivity;
-import androidx.fragment.app.FragmentManager;
-
-import com.facebook.react.bridge.*;
-import com.facebook.react.common.annotations.VisibleForTesting;
-import com.facebook.react.module.annotations.ReactModule;
-
-import static com.reactcommunity.rndatetimepicker.Common.dismissDialog;
-
-import java.util.Calendar;
-
-/**
- * {@link NativeModule} that allows JS to show a native date picker dialog and get called back when
- * the user selects a date.
- */
-@ReactModule(name = DatePickerModule.NAME)
-public class DatePickerModule extends NativeModuleDatePickerSpec {
-
-  @VisibleForTesting
-  public static final String NAME = "RNCDatePicker";
-
-  public DatePickerModule(ReactApplicationContext reactContext) {
-    super(reactContext);
-  }
-
-  @NonNull
-  @Override
-  public String getName() {
-    return NAME;
-  }
-
-  private class DatePickerDialogListener implements OnDateSetListener, OnDismissListener, OnClickListener {
-
-    private final Promise mPromise;
-    private final Bundle mArgs;
-    private boolean mPromiseResolved = false;
-
-    public DatePickerDialogListener(final Promise promise, Bundle arguments) {
-      mPromise = promise;
-      mArgs = arguments;
-    }
-
-    @Override
-    public void onDateSet(DatePicker view, int year, int month, int day) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
-        final RNDate date = new RNDate(mArgs);
-        Calendar calendar = Calendar.getInstance(Common.getTimeZone(mArgs));
-        calendar.set(year, month, day, date.hour(), date.minute(), 0);
-        calendar.set(Calendar.MILLISECOND, 0);
-
-        WritableMap result = new WritableNativeMap();
-        result.putString("action", RNConstants.ACTION_DATE_SET);
-        result.putDouble("timestamp", calendar.getTimeInMillis());
-        result.putDouble("utcOffset", calendar.getTimeZone().getOffset(calendar.getTimeInMillis()) / 1000 / 60);
-
-        mPromise.resolve(result);
-        mPromiseResolved = true;
-      }
-    }
-
-    @Override
-    public void onDismiss(DialogInterface dialog) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
-        WritableMap result = new WritableNativeMap();
-        result.putString("action", RNConstants.ACTION_DISMISSED);
-        mPromise.resolve(result);
-        mPromiseResolved = true;
-      }
-    }
-
-    @Override
-    public void onClick(DialogInterface dialog, int which) {
-      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
-        WritableMap result = new WritableNativeMap();
-        result.putString("action", RNConstants.ACTION_NEUTRAL_BUTTON);
-        mPromise.resolve(result);
-        mPromiseResolved = true;
-      }
-    }
-  }
-
-  @ReactMethod
-  public void dismiss(Promise promise) {
-    FragmentActivity activity = (FragmentActivity) getCurrentActivity();
-    dismissDialog(activity, NAME, promise);
-  }
-  /**
-   * Show a date picker dialog.
-   *
-   * @param options a map containing options. Available keys are:
-   *
-   * <ul>
-   *   <li>{@code date} (timestamp in milliseconds) the date to show by default</li>
-   *   <li>
-   *     {@code minimumDate} (timestamp in milliseconds) the minimum date the user should be allowed
-   *     to select
-   *   </li>
-   *   <li>
-   *     {@code maximumDate} (timestamp in milliseconds) the maximum date the user should be allowed
-   *     to select
-   *    </li>
-   *   <li>
-   *      {@code display} To set the date picker display to 'calendar/spinner/default'
-   *   </li>
-   *   <li>
-   *      {@code testID} testID for testing with e.g. detox.
-   *   </li>
-   * </ul>
-   *
-   * @param promise This will be invoked with parameters action, year,
-   *                month (0-11), day, where action is {@code dateSetAction} or
-   *                {@code dismissedAction}, depending on what the user did. If the action is
-   *                dismiss, year, month and date are undefined.
-   */
-  @ReactMethod
-  public void open(final ReadableMap options, final Promise promise) {
-    FragmentActivity activity = (FragmentActivity) getCurrentActivity();
-    if (activity == null) {
-      promise.reject(
-              RNConstants.ERROR_NO_ACTIVITY,
-              "Tried to open a DatePicker dialog while not attached to an Activity");
-      return;
-    }
-
-    final FragmentManager fragmentManager = activity.getSupportFragmentManager();
-
-    UiThreadUtil.runOnUiThread(() -> {
-      RNDatePickerDialogFragment oldFragment =
-              (RNDatePickerDialogFragment) fragmentManager.findFragmentByTag(NAME);
-
-      Bundle arguments = createFragmentArguments(options);
-
-      if (oldFragment != null) {
-        oldFragment.update(arguments);
-        return;
-      }
-
-      RNDatePickerDialogFragment fragment = new RNDatePickerDialogFragment();
-
-      fragment.setArguments(arguments);
-
-      final DatePickerDialogListener listener = new DatePickerDialogListener(promise, arguments);
-      fragment.setOnDismissListener(listener);
-      fragment.setOnDateSetListener(listener);
-      fragment.setOnNeutralButtonActionListener(listener);
-      fragment.show(fragmentManager, NAME);
-    });
-  }
-
-  private Bundle createFragmentArguments(ReadableMap options) {
-    final Bundle args = Common.createFragmentArguments(options);
-
-    if (options.hasKey(RNConstants.ARG_MINDATE) && !options.isNull(RNConstants.ARG_MINDATE)) {
-      args.putLong(RNConstants.ARG_MINDATE, (long) options.getDouble(RNConstants.ARG_MINDATE));
-    }
-    if (options.hasKey(RNConstants.ARG_MAXDATE) && !options.isNull(RNConstants.ARG_MAXDATE)) {
-      args.putLong(RNConstants.ARG_MAXDATE, (long) options.getDouble(RNConstants.ARG_MAXDATE));
-    }
-    if (options.hasKey(RNConstants.ARG_DISPLAY) && !options.isNull(RNConstants.ARG_DISPLAY)) {
-      args.putString(RNConstants.ARG_DISPLAY, options.getString(RNConstants.ARG_DISPLAY));
-    }
-    if (options.hasKey(RNConstants.ARG_DIALOG_BUTTONS) && !options.isNull(RNConstants.ARG_DIALOG_BUTTONS)) {
-      args.putBundle(RNConstants.ARG_DIALOG_BUTTONS, Arguments.toBundle(options.getMap(RNConstants.ARG_DIALOG_BUTTONS)));
-    }
-    if (options.hasKey(RNConstants.ARG_TZOFFSET_MINS) && !options.isNull(RNConstants.ARG_TZOFFSET_MINS)) {
-      args.putLong(RNConstants.ARG_TZOFFSET_MINS, (long) options.getDouble(RNConstants.ARG_TZOFFSET_MINS));
-    }
-    if (options.hasKey(RNConstants.ARG_TESTID) && !options.isNull(RNConstants.ARG_TESTID)) {
-      args.putString(RNConstants.ARG_TESTID, options.getString(RNConstants.ARG_TESTID));
-    }
-    return args;
-  }
-}
+ import android.app.DatePickerDialog.OnDateSetListener;
+ import android.content.DialogInterface;
+ import android.content.DialogInterface.OnDismissListener;
+ import android.content.DialogInterface.OnClickListener;
+ import android.os.Bundle;
+ import android.widget.DatePicker;
+ import androidx.annotation.NonNull;
+ import androidx.fragment.app.FragmentActivity;
+ import androidx.fragment.app.FragmentManager;
+ 
+ import com.facebook.react.bridge.*;
+ import com.facebook.react.common.annotations.VisibleForTesting;
+ import com.facebook.react.module.annotations.ReactModule;
+ 
+ import static com.reactcommunity.rndatetimepicker.Common.dismissDialog;
+ 
+ import java.util.Calendar;
+ 
+ /**
+  * {@link NativeModule} that allows JS to show a native date picker dialog and get called back when
+  * the user selects a date.
+  */
+ @ReactModule(name = DatePickerModule.NAME)
+ public class DatePickerModule extends NativeModuleDatePickerSpec {
+ 
+   @VisibleForTesting
+   public static final String NAME = "RNCDatePicker";
+ 
+   public DatePickerModule(ReactApplicationContext reactContext) {
+     super(reactContext);
+   }
+ 
+   @NonNull
+   @Override
+   public String getName() {
+     return NAME;
+   }
+ 
+   private class DatePickerDialogListener implements OnDateSetListener, OnDismissListener, OnClickListener {
+ 
+     private final Promise mPromise;
+     private final Bundle mArgs;
+     private boolean mPromiseResolved = false;
+ 
+     public DatePickerDialogListener(final Promise promise, Bundle arguments) {
+       mPromise = promise;
+       mArgs = arguments;
+     }
+ 
+     @Override
+     public void onDateSet(DatePicker view, int year, int month, int day) {
+       if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
+         final RNDate date = new RNDate(mArgs);
+         Calendar calendar = Calendar.getInstance(Common.getTimeZone(mArgs));
+         calendar.set(year, month, day, date.hour(), date.minute(), 0);
+         calendar.set(Calendar.MILLISECOND, 0);
+ 
+         WritableMap result = new WritableNativeMap();
+         result.putString("action", RNConstants.ACTION_DATE_SET);
+         result.putDouble("timestamp", calendar.getTimeInMillis());
+         result.putDouble("utcOffset", calendar.getTimeZone().getOffset(calendar.getTimeInMillis()) / 1000 / 60);
+ 
+         mPromise.resolve(result);
+         mPromiseResolved = true;
+       }
+     }
+ 
+     @Override
+     public void onDismiss(DialogInterface dialog) {
+       if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
+         WritableMap result = new WritableNativeMap();
+         result.putString("action", RNConstants.ACTION_DISMISSED);
+         mPromise.resolve(result);
+         mPromiseResolved = true;
+       }
+     }
+ 
+     @Override
+     public void onClick(DialogInterface dialog, int which) {
+       if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
+         WritableMap result = new WritableNativeMap();
+         result.putString("action", RNConstants.ACTION_NEUTRAL_BUTTON);
+         mPromise.resolve(result);
+         mPromiseResolved = true;
+       }
+     }
+   }
+ 
+   @ReactMethod
+   public void dismiss(Promise promise) {
+     FragmentActivity activity = (FragmentActivity) getCurrentActivity();
+     dismissDialog(activity, NAME, promise);
+   }
+   /**
+    * Show a date picker dialog.
+    *
+    * @param options a map containing options. Available keys are:
+    *
+    * <ul>
+    *   <li>{@code date} (timestamp in milliseconds) the date to show by default</li>
+    *   <li>
+    *     {@code minimumDate} (timestamp in milliseconds) the minimum date the user should be allowed
+    *     to select
+    *   </li>
+    *   <li>
+    *     {@code maximumDate} (timestamp in milliseconds) the maximum date the user should be allowed
+    *     to select
+    *    </li>
+    *   <li>
+    *      {@code display} To set the date picker display to 'calendar/spinner/default'
+    *   </li>
+    *   <li>
+    *      {@code testID} testID for testing with e.g. detox.
+    *   </li>
+    * </ul>
+    *
+    * @param promise This will be invoked with parameters action, year,
+    *                month (0-11), day, where action is {@code dateSetAction} or
+    *                {@code dismissedAction}, depending on what the user did. If the action is
+    *                dismiss, year, month and date are undefined.
+    */
+   @ReactMethod
+   public void open(final ReadableMap options, final Promise promise) {
+     FragmentActivity activity = (FragmentActivity) getCurrentActivity();
+     if (activity == null) {
+       promise.reject(
+               RNConstants.ERROR_NO_ACTIVITY,
+               "Tried to open a DatePicker dialog while not attached to an Activity");
+       return;
+     }
+ 
+     final FragmentManager fragmentManager = activity.getSupportFragmentManager();
+ 
+     UiThreadUtil.runOnUiThread(() -> {
+       RNDatePickerDialogFragment oldFragment =
+               (RNDatePickerDialogFragment) fragmentManager.findFragmentByTag(NAME);
+ 
+       Bundle arguments = createFragmentArguments(options);
+ 
+       if (oldFragment != null) {
+         oldFragment.update(arguments);
+         return;
+       }
+ 
+       RNDatePickerDialogFragment fragment = new RNDatePickerDialogFragment();
+ 
+       fragment.setArguments(arguments);
+ 
+       final DatePickerDialogListener listener = new DatePickerDialogListener(promise, arguments);
+       fragment.setOnDismissListener(listener);
+       fragment.setOnDateSetListener(listener);
+       fragment.setOnNeutralButtonActionListener(listener);
+       fragment.show(fragmentManager, NAME);
+     });
+   }
+ 
+   private Bundle createFragmentArguments(ReadableMap options) {
+     final Bundle args = Common.createFragmentArguments(options);
+     
+     if (options.hasKey(RNConstants.ARG_MINDATE) && !options.isNull(RNConstants.ARG_MINDATE)) {
+       args.putLong(RNConstants.ARG_MINDATE, (long) options.getDouble(RNConstants.ARG_MINDATE));
+     }
+     if (options.hasKey(RNConstants.ARG_MAXDATE) && !options.isNull(RNConstants.ARG_MAXDATE)) {
+       args.putLong(RNConstants.ARG_MAXDATE, (long) options.getDouble(RNConstants.ARG_MAXDATE));
+     }
+     if (options.hasKey(RNConstants.ARG_DISPLAY) && !options.isNull(RNConstants.ARG_DISPLAY)) {
+       args.putString(RNConstants.ARG_DISPLAY, options.getString(RNConstants.ARG_DISPLAY));
+     }
+     if (options.hasKey(RNConstants.ARG_DIALOG_BUTTONS) && !options.isNull(RNConstants.ARG_DIALOG_BUTTONS)) {
+       args.putBundle(RNConstants.ARG_DIALOG_BUTTONS, Arguments.toBundle(options.getMap(RNConstants.ARG_DIALOG_BUTTONS)));
+     }
+     if (options.hasKey(RNConstants.ARG_TZOFFSET_MINS) && !options.isNull(RNConstants.ARG_TZOFFSET_MINS)) {
+       args.putLong(RNConstants.ARG_TZOFFSET_MINS, (long) options.getDouble(RNConstants.ARG_TZOFFSET_MINS));
+     }
+     if (options.hasKey(RNConstants.ARG_TESTID) && !options.isNull(RNConstants.ARG_TESTID)) {
+       args.putString(RNConstants.ARG_TESTID, options.getString(RNConstants.ARG_TESTID));
+     }
+     if (options.hasKey(RNConstants.FIRST_DAY_OF_WEEK) && !options.isNull(RNConstants.FIRST_DAY_OF_WEEK)) {
+       // FIRST_DAY_OF_WEEK is 0-indexed, since it uses the same constants DAY_OF_WEEK used in the Windows implementation
+       // Android DatePicker uses 1-indexed values, SUNDAY being 1 and SATURDAY being 7, so the +1 is necessary in this case
+       args.putInt(RNConstants.FIRST_DAY_OF_WEEK, options.getInt(RNConstants.FIRST_DAY_OF_WEEK)+1);
+     }
+     return args;
+   }
+ }
+ 

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/DatePickerModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/DatePickerModule.java
@@ -5,191 +5,190 @@
  * LICENSE file in the root directory of this source tree.
  */
 
- package com.reactcommunity.rndatetimepicker;
+package com.reactcommunity.rndatetimepicker;
 
- import android.app.DatePickerDialog.OnDateSetListener;
- import android.content.DialogInterface;
- import android.content.DialogInterface.OnDismissListener;
- import android.content.DialogInterface.OnClickListener;
- import android.os.Bundle;
- import android.widget.DatePicker;
- import androidx.annotation.NonNull;
- import androidx.fragment.app.FragmentActivity;
- import androidx.fragment.app.FragmentManager;
- 
- import com.facebook.react.bridge.*;
- import com.facebook.react.common.annotations.VisibleForTesting;
- import com.facebook.react.module.annotations.ReactModule;
- 
- import static com.reactcommunity.rndatetimepicker.Common.dismissDialog;
- 
- import java.util.Calendar;
- 
- /**
-  * {@link NativeModule} that allows JS to show a native date picker dialog and get called back when
-  * the user selects a date.
+import android.app.DatePickerDialog.OnDateSetListener;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnDismissListener;
+import android.content.DialogInterface.OnClickListener;
+import android.os.Bundle;
+import android.widget.DatePicker;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import com.facebook.react.bridge.*;
+import com.facebook.react.common.annotations.VisibleForTesting;
+import com.facebook.react.module.annotations.ReactModule;
+
+import static com.reactcommunity.rndatetimepicker.Common.dismissDialog;
+
+import java.util.Calendar;
+
+/**
+* {@link NativeModule} that allows JS to show a native date picker dialog and get called back when
+* the user selects a date.
+*/
+@ReactModule(name = DatePickerModule.NAME)
+public class DatePickerModule extends NativeModuleDatePickerSpec {
+
+  @VisibleForTesting
+  public static final String NAME = "RNCDatePicker";
+
+  public DatePickerModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+  }
+
+  @NonNull
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  private class DatePickerDialogListener implements OnDateSetListener, OnDismissListener, OnClickListener {
+
+    private final Promise mPromise;
+    private final Bundle mArgs;
+    private boolean mPromiseResolved = false;
+
+    public DatePickerDialogListener(final Promise promise, Bundle arguments) {
+      mPromise = promise;
+      mArgs = arguments;
+    }
+
+    @Override
+    public void onDateSet(DatePicker view, int year, int month, int day) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
+        final RNDate date = new RNDate(mArgs);
+        Calendar calendar = Calendar.getInstance(Common.getTimeZone(mArgs));
+        calendar.set(year, month, day, date.hour(), date.minute(), 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+
+        WritableMap result = new WritableNativeMap();
+        result.putString("action", RNConstants.ACTION_DATE_SET);
+        result.putDouble("timestamp", calendar.getTimeInMillis());
+        result.putDouble("utcOffset", calendar.getTimeZone().getOffset(calendar.getTimeInMillis()) / 1000 / 60);
+
+        mPromise.resolve(result);
+        mPromiseResolved = true;
+      }
+    }
+
+    @Override
+    public void onDismiss(DialogInterface dialog) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
+        WritableMap result = new WritableNativeMap();
+        result.putString("action", RNConstants.ACTION_DISMISSED);
+        mPromise.resolve(result);
+        mPromiseResolved = true;
+      }
+    }
+
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
+      if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
+        WritableMap result = new WritableNativeMap();
+        result.putString("action", RNConstants.ACTION_NEUTRAL_BUTTON);
+        mPromise.resolve(result);
+        mPromiseResolved = true;
+      }
+    }
+  }
+
+  @ReactMethod
+  public void dismiss(Promise promise) {
+    FragmentActivity activity = (FragmentActivity) getCurrentActivity();
+    dismissDialog(activity, NAME, promise);
+  }
+  /**
+  * Show a date picker dialog.
+  *
+  * @param options a map containing options. Available keys are:
+  *
+  * <ul>
+  *   <li>{@code date} (timestamp in milliseconds) the date to show by default</li>
+  *   <li>
+  *     {@code minimumDate} (timestamp in milliseconds) the minimum date the user should be allowed
+  *     to select
+  *   </li>
+  *   <li>
+  *     {@code maximumDate} (timestamp in milliseconds) the maximum date the user should be allowed
+  *     to select
+  *    </li>
+  *   <li>
+  *      {@code display} To set the date picker display to 'calendar/spinner/default'
+  *   </li>
+  *   <li>
+  *      {@code testID} testID for testing with e.g. detox.
+  *   </li>
+  * </ul>
+  *
+  * @param promise This will be invoked with parameters action, year,
+  *                month (0-11), day, where action is {@code dateSetAction} or
+  *                {@code dismissedAction}, depending on what the user did. If the action is
+  *                dismiss, year, month and date are undefined.
   */
- @ReactModule(name = DatePickerModule.NAME)
- public class DatePickerModule extends NativeModuleDatePickerSpec {
- 
-   @VisibleForTesting
-   public static final String NAME = "RNCDatePicker";
- 
-   public DatePickerModule(ReactApplicationContext reactContext) {
-     super(reactContext);
-   }
- 
-   @NonNull
-   @Override
-   public String getName() {
-     return NAME;
-   }
- 
-   private class DatePickerDialogListener implements OnDateSetListener, OnDismissListener, OnClickListener {
- 
-     private final Promise mPromise;
-     private final Bundle mArgs;
-     private boolean mPromiseResolved = false;
- 
-     public DatePickerDialogListener(final Promise promise, Bundle arguments) {
-       mPromise = promise;
-       mArgs = arguments;
-     }
- 
-     @Override
-     public void onDateSet(DatePicker view, int year, int month, int day) {
-       if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
-         final RNDate date = new RNDate(mArgs);
-         Calendar calendar = Calendar.getInstance(Common.getTimeZone(mArgs));
-         calendar.set(year, month, day, date.hour(), date.minute(), 0);
-         calendar.set(Calendar.MILLISECOND, 0);
- 
-         WritableMap result = new WritableNativeMap();
-         result.putString("action", RNConstants.ACTION_DATE_SET);
-         result.putDouble("timestamp", calendar.getTimeInMillis());
-         result.putDouble("utcOffset", calendar.getTimeZone().getOffset(calendar.getTimeInMillis()) / 1000 / 60);
- 
-         mPromise.resolve(result);
-         mPromiseResolved = true;
-       }
-     }
- 
-     @Override
-     public void onDismiss(DialogInterface dialog) {
-       if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
-         WritableMap result = new WritableNativeMap();
-         result.putString("action", RNConstants.ACTION_DISMISSED);
-         mPromise.resolve(result);
-         mPromiseResolved = true;
-       }
-     }
- 
-     @Override
-     public void onClick(DialogInterface dialog, int which) {
-       if (!mPromiseResolved && getReactApplicationContext().hasActiveReactInstance()) {
-         WritableMap result = new WritableNativeMap();
-         result.putString("action", RNConstants.ACTION_NEUTRAL_BUTTON);
-         mPromise.resolve(result);
-         mPromiseResolved = true;
-       }
-     }
-   }
- 
-   @ReactMethod
-   public void dismiss(Promise promise) {
-     FragmentActivity activity = (FragmentActivity) getCurrentActivity();
-     dismissDialog(activity, NAME, promise);
-   }
-   /**
-    * Show a date picker dialog.
-    *
-    * @param options a map containing options. Available keys are:
-    *
-    * <ul>
-    *   <li>{@code date} (timestamp in milliseconds) the date to show by default</li>
-    *   <li>
-    *     {@code minimumDate} (timestamp in milliseconds) the minimum date the user should be allowed
-    *     to select
-    *   </li>
-    *   <li>
-    *     {@code maximumDate} (timestamp in milliseconds) the maximum date the user should be allowed
-    *     to select
-    *    </li>
-    *   <li>
-    *      {@code display} To set the date picker display to 'calendar/spinner/default'
-    *   </li>
-    *   <li>
-    *      {@code testID} testID for testing with e.g. detox.
-    *   </li>
-    * </ul>
-    *
-    * @param promise This will be invoked with parameters action, year,
-    *                month (0-11), day, where action is {@code dateSetAction} or
-    *                {@code dismissedAction}, depending on what the user did. If the action is
-    *                dismiss, year, month and date are undefined.
-    */
-   @ReactMethod
-   public void open(final ReadableMap options, final Promise promise) {
-     FragmentActivity activity = (FragmentActivity) getCurrentActivity();
-     if (activity == null) {
-       promise.reject(
-               RNConstants.ERROR_NO_ACTIVITY,
-               "Tried to open a DatePicker dialog while not attached to an Activity");
-       return;
-     }
- 
-     final FragmentManager fragmentManager = activity.getSupportFragmentManager();
- 
-     UiThreadUtil.runOnUiThread(() -> {
-       RNDatePickerDialogFragment oldFragment =
-               (RNDatePickerDialogFragment) fragmentManager.findFragmentByTag(NAME);
- 
-       Bundle arguments = createFragmentArguments(options);
- 
-       if (oldFragment != null) {
-         oldFragment.update(arguments);
-         return;
-       }
- 
-       RNDatePickerDialogFragment fragment = new RNDatePickerDialogFragment();
- 
-       fragment.setArguments(arguments);
- 
-       final DatePickerDialogListener listener = new DatePickerDialogListener(promise, arguments);
-       fragment.setOnDismissListener(listener);
-       fragment.setOnDateSetListener(listener);
-       fragment.setOnNeutralButtonActionListener(listener);
-       fragment.show(fragmentManager, NAME);
-     });
-   }
- 
-   private Bundle createFragmentArguments(ReadableMap options) {
-     final Bundle args = Common.createFragmentArguments(options);
-     
-     if (options.hasKey(RNConstants.ARG_MINDATE) && !options.isNull(RNConstants.ARG_MINDATE)) {
-       args.putLong(RNConstants.ARG_MINDATE, (long) options.getDouble(RNConstants.ARG_MINDATE));
-     }
-     if (options.hasKey(RNConstants.ARG_MAXDATE) && !options.isNull(RNConstants.ARG_MAXDATE)) {
-       args.putLong(RNConstants.ARG_MAXDATE, (long) options.getDouble(RNConstants.ARG_MAXDATE));
-     }
-     if (options.hasKey(RNConstants.ARG_DISPLAY) && !options.isNull(RNConstants.ARG_DISPLAY)) {
-       args.putString(RNConstants.ARG_DISPLAY, options.getString(RNConstants.ARG_DISPLAY));
-     }
-     if (options.hasKey(RNConstants.ARG_DIALOG_BUTTONS) && !options.isNull(RNConstants.ARG_DIALOG_BUTTONS)) {
-       args.putBundle(RNConstants.ARG_DIALOG_BUTTONS, Arguments.toBundle(options.getMap(RNConstants.ARG_DIALOG_BUTTONS)));
-     }
-     if (options.hasKey(RNConstants.ARG_TZOFFSET_MINS) && !options.isNull(RNConstants.ARG_TZOFFSET_MINS)) {
-       args.putLong(RNConstants.ARG_TZOFFSET_MINS, (long) options.getDouble(RNConstants.ARG_TZOFFSET_MINS));
-     }
-     if (options.hasKey(RNConstants.ARG_TESTID) && !options.isNull(RNConstants.ARG_TESTID)) {
-       args.putString(RNConstants.ARG_TESTID, options.getString(RNConstants.ARG_TESTID));
-     }
-     if (options.hasKey(RNConstants.FIRST_DAY_OF_WEEK) && !options.isNull(RNConstants.FIRST_DAY_OF_WEEK)) {
-       // FIRST_DAY_OF_WEEK is 0-indexed, since it uses the same constants DAY_OF_WEEK used in the Windows implementation
-       // Android DatePicker uses 1-indexed values, SUNDAY being 1 and SATURDAY being 7, so the +1 is necessary in this case
-       args.putInt(RNConstants.FIRST_DAY_OF_WEEK, options.getInt(RNConstants.FIRST_DAY_OF_WEEK)+1);
-     }
-     return args;
-   }
- }
- 
+  @ReactMethod
+  public void open(final ReadableMap options, final Promise promise) {
+    FragmentActivity activity = (FragmentActivity) getCurrentActivity();
+    if (activity == null) {
+      promise.reject(
+              RNConstants.ERROR_NO_ACTIVITY,
+              "Tried to open a DatePicker dialog while not attached to an Activity");
+      return;
+    }
+
+    final FragmentManager fragmentManager = activity.getSupportFragmentManager();
+
+    UiThreadUtil.runOnUiThread(() -> {
+      RNDatePickerDialogFragment oldFragment =
+              (RNDatePickerDialogFragment) fragmentManager.findFragmentByTag(NAME);
+
+      Bundle arguments = createFragmentArguments(options);
+
+      if (oldFragment != null) {
+        oldFragment.update(arguments);
+        return;
+      }
+
+      RNDatePickerDialogFragment fragment = new RNDatePickerDialogFragment();
+
+      fragment.setArguments(arguments);
+
+      final DatePickerDialogListener listener = new DatePickerDialogListener(promise, arguments);
+      fragment.setOnDismissListener(listener);
+      fragment.setOnDateSetListener(listener);
+      fragment.setOnNeutralButtonActionListener(listener);
+      fragment.show(fragmentManager, NAME);
+    });
+  }
+
+  private Bundle createFragmentArguments(ReadableMap options) {
+    final Bundle args = Common.createFragmentArguments(options);
+    
+    if (options.hasKey(RNConstants.ARG_MINDATE) && !options.isNull(RNConstants.ARG_MINDATE)) {
+      args.putLong(RNConstants.ARG_MINDATE, (long) options.getDouble(RNConstants.ARG_MINDATE));
+    }
+    if (options.hasKey(RNConstants.ARG_MAXDATE) && !options.isNull(RNConstants.ARG_MAXDATE)) {
+      args.putLong(RNConstants.ARG_MAXDATE, (long) options.getDouble(RNConstants.ARG_MAXDATE));
+    }
+    if (options.hasKey(RNConstants.ARG_DISPLAY) && !options.isNull(RNConstants.ARG_DISPLAY)) {
+      args.putString(RNConstants.ARG_DISPLAY, options.getString(RNConstants.ARG_DISPLAY));
+    }
+    if (options.hasKey(RNConstants.ARG_DIALOG_BUTTONS) && !options.isNull(RNConstants.ARG_DIALOG_BUTTONS)) {
+      args.putBundle(RNConstants.ARG_DIALOG_BUTTONS, Arguments.toBundle(options.getMap(RNConstants.ARG_DIALOG_BUTTONS)));
+    }
+    if (options.hasKey(RNConstants.ARG_TZOFFSET_MINS) && !options.isNull(RNConstants.ARG_TZOFFSET_MINS)) {
+      args.putLong(RNConstants.ARG_TZOFFSET_MINS, (long) options.getDouble(RNConstants.ARG_TZOFFSET_MINS));
+    }
+    if (options.hasKey(RNConstants.ARG_TESTID) && !options.isNull(RNConstants.ARG_TESTID)) {
+      args.putString(RNConstants.ARG_TESTID, options.getString(RNConstants.ARG_TESTID));
+    }
+    if (options.hasKey(RNConstants.FIRST_DAY_OF_WEEK) && !options.isNull(RNConstants.FIRST_DAY_OF_WEEK)) {
+      // FIRST_DAY_OF_WEEK is 0-indexed, since it uses the same constants DAY_OF_WEEK used in the Windows implementation
+      // Android DatePicker uses 1-indexed values, SUNDAY being 1 and SATURDAY being 7, so the +1 is necessary in this case
+      args.putInt(RNConstants.FIRST_DAY_OF_WEEK, options.getInt(RNConstants.FIRST_DAY_OF_WEEK)+1);
+    }
+    return args;
+  }
+}

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/DatePickerModule.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/DatePickerModule.java
@@ -26,9 +26,9 @@ import static com.reactcommunity.rndatetimepicker.Common.dismissDialog;
 import java.util.Calendar;
 
 /**
-* {@link NativeModule} that allows JS to show a native date picker dialog and get called back when
-* the user selects a date.
-*/
+ * {@link NativeModule} that allows JS to show a native date picker dialog and get called back when
+ * the user selects a date.
+ */
 @ReactModule(name = DatePickerModule.NAME)
 public class DatePickerModule extends NativeModuleDatePickerSpec {
 
@@ -101,33 +101,33 @@ public class DatePickerModule extends NativeModuleDatePickerSpec {
     dismissDialog(activity, NAME, promise);
   }
   /**
-  * Show a date picker dialog.
-  *
-  * @param options a map containing options. Available keys are:
-  *
-  * <ul>
-  *   <li>{@code date} (timestamp in milliseconds) the date to show by default</li>
-  *   <li>
-  *     {@code minimumDate} (timestamp in milliseconds) the minimum date the user should be allowed
-  *     to select
-  *   </li>
-  *   <li>
-  *     {@code maximumDate} (timestamp in milliseconds) the maximum date the user should be allowed
-  *     to select
-  *    </li>
-  *   <li>
-  *      {@code display} To set the date picker display to 'calendar/spinner/default'
-  *   </li>
-  *   <li>
-  *      {@code testID} testID for testing with e.g. detox.
-  *   </li>
-  * </ul>
-  *
-  * @param promise This will be invoked with parameters action, year,
-  *                month (0-11), day, where action is {@code dateSetAction} or
-  *                {@code dismissedAction}, depending on what the user did. If the action is
-  *                dismiss, year, month and date are undefined.
-  */
+   * Show a date picker dialog.
+   *
+   * @param options a map containing options. Available keys are:
+   *
+   * <ul>
+   *   <li>{@code date} (timestamp in milliseconds) the date to show by default</li>
+   *   <li>
+   *     {@code minimumDate} (timestamp in milliseconds) the minimum date the user should be allowed
+   *     to select
+   *   </li>
+   *   <li>
+   *     {@code maximumDate} (timestamp in milliseconds) the maximum date the user should be allowed
+   *     to select
+   *    </li>
+   *   <li>
+   *      {@code display} To set the date picker display to 'calendar/spinner/default'
+   *   </li>
+   *   <li>
+   *      {@code testID} testID for testing with e.g. detox.
+   *   </li>
+   * </ul>
+   *
+   * @param promise This will be invoked with parameters action, year,
+   *                month (0-11), day, where action is {@code dateSetAction} or
+   *                {@code dismissedAction}, depending on what the user did. If the action is
+   *                dismiss, year, month and date are undefined.
+   */
   @ReactMethod
   public void open(final ReadableMap options, final Promise promise) {
     FragmentActivity activity = (FragmentActivity) getCurrentActivity();
@@ -165,7 +165,7 @@ public class DatePickerModule extends NativeModuleDatePickerSpec {
 
   private Bundle createFragmentArguments(ReadableMap options) {
     final Bundle args = Common.createFragmentArguments(options);
-    
+
     if (options.hasKey(RNConstants.ARG_MINDATE) && !options.isNull(RNConstants.ARG_MINDATE)) {
       args.putLong(RNConstants.ARG_MINDATE, (long) options.getDouble(RNConstants.ARG_MINDATE));
     }

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNConstants.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNConstants.java
@@ -18,6 +18,7 @@ public final class RNConstants {
   public static final String ACTION_TIME_SET = "timeSetAction";
   public static final String ACTION_DISMISSED = "dismissedAction";
   public static final String ACTION_NEUTRAL_BUTTON = "neutralButtonAction";
+  public static final String FIRST_DAY_OF_WEEK = "firstDayOfWeek";
 
   /**
    * Minimum date supported by {@link TimePickerDialog}, 01 Jan 1900

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
@@ -5,160 +5,159 @@
  * LICENSE file in the root directory of this source tree.
  */
 
- package com.reactcommunity.rndatetimepicker;
+package com.reactcommunity.rndatetimepicker;
 
- import static com.reactcommunity.rndatetimepicker.Common.getDisplayDate;
- import static com.reactcommunity.rndatetimepicker.Common.setButtonTextColor;
- import static com.reactcommunity.rndatetimepicker.Common.setButtonTitles;
- 
- import android.annotation.SuppressLint;
- import android.app.DatePickerDialog;
- import android.app.DatePickerDialog.OnDateSetListener;
- import android.app.Dialog;
- import android.content.Context;
- import android.content.DialogInterface;
- import android.content.DialogInterface.OnDismissListener;
- import android.content.DialogInterface.OnClickListener;
- import android.os.Build;
- import android.os.Bundle;
- 
- import androidx.annotation.NonNull;
- import androidx.annotation.Nullable;
- import androidx.fragment.app.DialogFragment;
- 
- import android.widget.DatePicker;
+import static com.reactcommunity.rndatetimepicker.Common.getDisplayDate;
+import static com.reactcommunity.rndatetimepicker.Common.setButtonTextColor;
+import static com.reactcommunity.rndatetimepicker.Common.setButtonTitles;
 
- import java.util.Calendar;
- import java.util.Locale;
- 
- @SuppressLint("ValidFragment")
- public class RNDatePickerDialogFragment extends DialogFragment {
-   private DatePickerDialog instance;
- 
-   @Nullable
-   private OnDateSetListener mOnDateSetListener;
-   @Nullable
-   private OnDismissListener mOnDismissListener;
-   @Nullable
-   private OnClickListener mOnNeutralButtonActionListener;
- 
-   @NonNull
-   @Override
-   public Dialog onCreateDialog(Bundle savedInstanceState) {
-     Bundle args = getArguments();
-     instance = createDialog(args);
-     return instance;
-   }
- 
-   public void update(Bundle args) {
-     final RNDate date = new RNDate(args);
-     instance.updateDate(date.year(), date.month(), date.day());
-   }
- 
-   static @NonNull
-   DatePickerDialog getDialog(
-           Bundle args,
-           Context activityContext,
-           @Nullable OnDateSetListener onDateSetListener) {
-     final RNDate date = new RNDate(args);
-     final int year = date.year();
-     final int month = date.month();
-     final int day = date.day();
- 
-     RNDatePickerDisplay display = getDisplayDate(args);
- 
-     if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
-       display = RNDatePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
-     }
- 
-     if (display == RNDatePickerDisplay.SPINNER) {
-       return new RNDismissableDatePickerDialog(
-         activityContext,
-         R.style.SpinnerDatePickerDialog,
-         onDateSetListener,
-         year,
-         month,
-         day,
-         display
-       );
-     }
-     return new RNDismissableDatePickerDialog(
-       activityContext,
-       onDateSetListener,
-       year,
-       month,
-       day,
-       display
-     );
-   }
- 
-   private DatePickerDialog createDialog(Bundle args) {
-     Context activityContext = getActivity();
-     DatePickerDialog dialog = getDialog(args, activityContext, mOnDateSetListener);
+import android.annotation.SuppressLint;
+import android.app.DatePickerDialog;
+import android.app.DatePickerDialog.OnDateSetListener;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnDismissListener;
+import android.content.DialogInterface.OnClickListener;
+import android.os.Build;
+import android.os.Bundle;
 
-     if (args != null) {
-       setButtonTitles(args, dialog, mOnNeutralButtonActionListener);
-       if (activityContext != null) {
-         RNDatePickerDisplay display = getDisplayDate(args);
-         boolean needsColorOverride = display == RNDatePickerDisplay.SPINNER;
-         dialog.setOnShowListener(setButtonTextColor(activityContext, dialog, args, needsColorOverride));
-       }
-     }
- 
-     final DatePicker datePicker = dialog.getDatePicker();
-     final long minDate = Common.minDateWithTimeZone(args);
-     final long maxDate = Common.maxDateWithTimeZone(args);
- 
-     if (args.containsKey(RNConstants.ARG_MINDATE)) {
-       datePicker.setMinDate(minDate);
-     } else {
-       // This is to work around a bug in DatePickerDialog where it doesn't display a title showing
-       // the date under certain conditions.
-       datePicker.setMinDate(RNConstants.DEFAULT_MIN_DATE);
-     }
-     
-     if (args.containsKey(RNConstants.FIRST_DAY_OF_WEEK)) {
-       final int firstDayOfWeek = args.getInt(RNConstants.FIRST_DAY_OF_WEEK);
-       datePicker.setFirstDayOfWeek(firstDayOfWeek);
-     }
- 
-     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && (args.containsKey(RNConstants.ARG_MAXDATE) || args.containsKey(RNConstants.ARG_MINDATE))) {
-       datePicker.setOnDateChangedListener((view, year, monthOfYear, dayOfMonth) -> {
-         Calendar calendar = Calendar.getInstance(Common.getTimeZone(args));
-         calendar.set(year, monthOfYear, dayOfMonth, 0, 0, 0);
-         long timestamp = Math.min(Math.max(calendar.getTimeInMillis(), minDate), maxDate);
-         calendar.setTimeInMillis(timestamp);
-         if (datePicker.getYear() != calendar.get(Calendar.YEAR) || datePicker.getMonth() != calendar.get(Calendar.MONTH) || datePicker.getDayOfMonth() != calendar.get(Calendar.DAY_OF_MONTH)) {
-           datePicker.updateDate(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH));
-         }
-       });
-     }
- 
-     if (args.containsKey(RNConstants.ARG_TESTID)) {
-       datePicker.setTag(args.getString(RNConstants.ARG_TESTID));
-     }
- 
-     return dialog;
-   }
- 
-   @Override
-   public void onDismiss(@NonNull DialogInterface dialog) {
-     super.onDismiss(dialog);
-     if (mOnDismissListener != null) {
-       mOnDismissListener.onDismiss(dialog);
-     }
-   }
- 
-   /*package*/ void setOnDateSetListener(@Nullable OnDateSetListener onDateSetListener) {
-     mOnDateSetListener = onDateSetListener;
-   }
- 
-   /*package*/ void setOnDismissListener(@Nullable OnDismissListener onDismissListener) {
-     mOnDismissListener = onDismissListener;
-   }
- 
-   /*package*/ void setOnNeutralButtonActionListener(@Nullable OnClickListener onNeutralButtonActionListener) {
-     mOnNeutralButtonActionListener = onNeutralButtonActionListener;
-   }
- }
- 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import android.widget.DatePicker;
+
+import java.util.Calendar;
+import java.util.Locale;
+
+@SuppressLint("ValidFragment")
+public class RNDatePickerDialogFragment extends DialogFragment {
+  private DatePickerDialog instance;
+
+  @Nullable
+  private OnDateSetListener mOnDateSetListener;
+  @Nullable
+  private OnDismissListener mOnDismissListener;
+  @Nullable
+  private OnClickListener mOnNeutralButtonActionListener;
+
+  @NonNull
+  @Override
+  public Dialog onCreateDialog(Bundle savedInstanceState) {
+    Bundle args = getArguments();
+    instance = createDialog(args);
+    return instance;
+  }
+
+  public void update(Bundle args) {
+    final RNDate date = new RNDate(args);
+    instance.updateDate(date.year(), date.month(), date.day());
+  }
+
+  static @NonNull
+  DatePickerDialog getDialog(
+          Bundle args,
+          Context activityContext,
+          @Nullable OnDateSetListener onDateSetListener) {
+    final RNDate date = new RNDate(args);
+    final int year = date.year();
+    final int month = date.month();
+    final int day = date.day();
+
+    RNDatePickerDisplay display = getDisplayDate(args);
+
+    if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
+      display = RNDatePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
+    }
+
+    if (display == RNDatePickerDisplay.SPINNER) {
+      return new RNDismissableDatePickerDialog(
+        activityContext,
+        R.style.SpinnerDatePickerDialog,
+        onDateSetListener,
+        year,
+        month,
+        day,
+        display
+      );
+    }
+    return new RNDismissableDatePickerDialog(
+      activityContext,
+      onDateSetListener,
+      year,
+      month,
+      day,
+      display
+    );
+  }
+
+  private DatePickerDialog createDialog(Bundle args) {
+    Context activityContext = getActivity();
+    DatePickerDialog dialog = getDialog(args, activityContext, mOnDateSetListener);
+
+    if (args != null) {
+      setButtonTitles(args, dialog, mOnNeutralButtonActionListener);
+      if (activityContext != null) {
+        RNDatePickerDisplay display = getDisplayDate(args);
+        boolean needsColorOverride = display == RNDatePickerDisplay.SPINNER;
+        dialog.setOnShowListener(setButtonTextColor(activityContext, dialog, args, needsColorOverride));
+      }
+    }
+
+    final DatePicker datePicker = dialog.getDatePicker();
+    final long minDate = Common.minDateWithTimeZone(args);
+    final long maxDate = Common.maxDateWithTimeZone(args);
+
+    if (args.containsKey(RNConstants.ARG_MINDATE)) {
+      datePicker.setMinDate(minDate);
+    } else {
+      // This is to work around a bug in DatePickerDialog where it doesn't display a title showing
+      // the date under certain conditions.
+      datePicker.setMinDate(RNConstants.DEFAULT_MIN_DATE);
+    }
+    
+    if (args.containsKey(RNConstants.FIRST_DAY_OF_WEEK)) {
+      final int firstDayOfWeek = args.getInt(RNConstants.FIRST_DAY_OF_WEEK);
+      datePicker.setFirstDayOfWeek(firstDayOfWeek);
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && (args.containsKey(RNConstants.ARG_MAXDATE) || args.containsKey(RNConstants.ARG_MINDATE))) {
+      datePicker.setOnDateChangedListener((view, year, monthOfYear, dayOfMonth) -> {
+        Calendar calendar = Calendar.getInstance(Common.getTimeZone(args));
+        calendar.set(year, monthOfYear, dayOfMonth, 0, 0, 0);
+        long timestamp = Math.min(Math.max(calendar.getTimeInMillis(), minDate), maxDate);
+        calendar.setTimeInMillis(timestamp);
+        if (datePicker.getYear() != calendar.get(Calendar.YEAR) || datePicker.getMonth() != calendar.get(Calendar.MONTH) || datePicker.getDayOfMonth() != calendar.get(Calendar.DAY_OF_MONTH)) {
+          datePicker.updateDate(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH));
+        }
+      });
+    }
+
+    if (args.containsKey(RNConstants.ARG_TESTID)) {
+      datePicker.setTag(args.getString(RNConstants.ARG_TESTID));
+    }
+
+    return dialog;
+  }
+
+  @Override
+  public void onDismiss(@NonNull DialogInterface dialog) {
+    super.onDismiss(dialog);
+    if (mOnDismissListener != null) {
+      mOnDismissListener.onDismiss(dialog);
+    }
+  }
+
+  /*package*/ void setOnDateSetListener(@Nullable OnDateSetListener onDateSetListener) {
+    mOnDateSetListener = onDateSetListener;
+  }
+
+  /*package*/ void setOnDismissListener(@Nullable OnDismissListener onDismissListener) {
+    mOnDismissListener = onDismissListener;
+  }
+
+  /*package*/ void setOnNeutralButtonActionListener(@Nullable OnClickListener onNeutralButtonActionListener) {
+    mOnNeutralButtonActionListener = onNeutralButtonActionListener;
+  }
+}

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
@@ -5,157 +5,160 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.reactcommunity.rndatetimepicker;
+ package com.reactcommunity.rndatetimepicker;
 
-import static com.reactcommunity.rndatetimepicker.Common.getDisplayDate;
-import static com.reactcommunity.rndatetimepicker.Common.setButtonTextColor;
-import static com.reactcommunity.rndatetimepicker.Common.setButtonTitles;
+ import static com.reactcommunity.rndatetimepicker.Common.getDisplayDate;
+ import static com.reactcommunity.rndatetimepicker.Common.setButtonTextColor;
+ import static com.reactcommunity.rndatetimepicker.Common.setButtonTitles;
+ 
+ import android.annotation.SuppressLint;
+ import android.app.DatePickerDialog;
+ import android.app.DatePickerDialog.OnDateSetListener;
+ import android.app.Dialog;
+ import android.content.Context;
+ import android.content.DialogInterface;
+ import android.content.DialogInterface.OnDismissListener;
+ import android.content.DialogInterface.OnClickListener;
+ import android.os.Build;
+ import android.os.Bundle;
+ 
+ import androidx.annotation.NonNull;
+ import androidx.annotation.Nullable;
+ import androidx.fragment.app.DialogFragment;
+ 
+ import android.widget.DatePicker;
 
-import android.annotation.SuppressLint;
-import android.app.DatePickerDialog;
-import android.app.DatePickerDialog.OnDateSetListener;
-import android.app.Dialog;
-import android.content.Context;
-import android.content.DialogInterface;
-import android.content.DialogInterface.OnDismissListener;
-import android.content.DialogInterface.OnClickListener;
-import android.os.Build;
-import android.os.Bundle;
+ import java.util.Calendar;
+ import java.util.Locale;
+ 
+ @SuppressLint("ValidFragment")
+ public class RNDatePickerDialogFragment extends DialogFragment {
+   private DatePickerDialog instance;
+ 
+   @Nullable
+   private OnDateSetListener mOnDateSetListener;
+   @Nullable
+   private OnDismissListener mOnDismissListener;
+   @Nullable
+   private OnClickListener mOnNeutralButtonActionListener;
+ 
+   @NonNull
+   @Override
+   public Dialog onCreateDialog(Bundle savedInstanceState) {
+     Bundle args = getArguments();
+     instance = createDialog(args);
+     return instance;
+   }
+ 
+   public void update(Bundle args) {
+     final RNDate date = new RNDate(args);
+     instance.updateDate(date.year(), date.month(), date.day());
+   }
+ 
+   static @NonNull
+   DatePickerDialog getDialog(
+           Bundle args,
+           Context activityContext,
+           @Nullable OnDateSetListener onDateSetListener) {
+     final RNDate date = new RNDate(args);
+     final int year = date.year();
+     final int month = date.month();
+     final int day = date.day();
+ 
+     RNDatePickerDisplay display = getDisplayDate(args);
+ 
+     if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
+       display = RNDatePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
+     }
+ 
+     if (display == RNDatePickerDisplay.SPINNER) {
+       return new RNDismissableDatePickerDialog(
+         activityContext,
+         R.style.SpinnerDatePickerDialog,
+         onDateSetListener,
+         year,
+         month,
+         day,
+         display
+       );
+     }
+     return new RNDismissableDatePickerDialog(
+       activityContext,
+       onDateSetListener,
+       year,
+       month,
+       day,
+       display
+     );
+   }
+ 
+   private DatePickerDialog createDialog(Bundle args) {
+     Context activityContext = getActivity();
+     DatePickerDialog dialog = getDialog(args, activityContext, mOnDateSetListener);
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.DialogFragment;
-
-import android.widget.DatePicker;
-
-import java.util.Calendar;
-import java.util.Locale;
-
-@SuppressLint("ValidFragment")
-public class RNDatePickerDialogFragment extends DialogFragment {
-  private DatePickerDialog instance;
-
-  @Nullable
-  private OnDateSetListener mOnDateSetListener;
-  @Nullable
-  private OnDismissListener mOnDismissListener;
-  @Nullable
-  private OnClickListener mOnNeutralButtonActionListener;
-
-  @NonNull
-  @Override
-  public Dialog onCreateDialog(Bundle savedInstanceState) {
-    Bundle args = getArguments();
-    instance = createDialog(args);
-    return instance;
-  }
-
-  public void update(Bundle args) {
-    final RNDate date = new RNDate(args);
-    instance.updateDate(date.year(), date.month(), date.day());
-  }
-
-  static @NonNull
-  DatePickerDialog getDialog(
-          Bundle args,
-          Context activityContext,
-          @Nullable OnDateSetListener onDateSetListener) {
-    final RNDate date = new RNDate(args);
-    final int year = date.year();
-    final int month = date.month();
-    final int day = date.day();
-
-    RNDatePickerDisplay display = getDisplayDate(args);
-
-    if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
-      display = RNDatePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
-    }
-
-    if (display == RNDatePickerDisplay.SPINNER) {
-      return new RNDismissableDatePickerDialog(
-        activityContext,
-        R.style.SpinnerDatePickerDialog,
-        onDateSetListener,
-        year,
-        month,
-        day,
-        display
-      );
-    }
-    return new RNDismissableDatePickerDialog(
-      activityContext,
-      onDateSetListener,
-      year,
-      month,
-      day,
-      display
-    );
-  }
-
-  private DatePickerDialog createDialog(Bundle args) {
-    Context activityContext = getActivity();
-    DatePickerDialog dialog = getDialog(args, activityContext, mOnDateSetListener);
-
-    if (args != null) {
-      setButtonTitles(args, dialog, mOnNeutralButtonActionListener);
-      if (activityContext != null) {
-        RNDatePickerDisplay display = getDisplayDate(args);
-        boolean needsColorOverride = display == RNDatePickerDisplay.SPINNER;
-        dialog.setOnShowListener(setButtonTextColor(activityContext, dialog, args, needsColorOverride));
-      }
-    }
-
-    final DatePicker datePicker = dialog.getDatePicker();
-    final long minDate = Common.minDateWithTimeZone(args);
-    final long maxDate = Common.maxDateWithTimeZone(args);
-
-    if (args.containsKey(RNConstants.ARG_MINDATE)) {
-      datePicker.setMinDate(minDate);
-    } else {
-      // This is to work around a bug in DatePickerDialog where it doesn't display a title showing
-      // the date under certain conditions.
-      datePicker.setMinDate(RNConstants.DEFAULT_MIN_DATE);
-    }
-    if (args.containsKey(RNConstants.ARG_MAXDATE)) {
-      datePicker.setMaxDate(maxDate);
-    }
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && (args.containsKey(RNConstants.ARG_MAXDATE) || args.containsKey(RNConstants.ARG_MINDATE))) {
-      datePicker.setOnDateChangedListener((view, year, monthOfYear, dayOfMonth) -> {
-        Calendar calendar = Calendar.getInstance(Common.getTimeZone(args));
-        calendar.set(year, monthOfYear, dayOfMonth, 0, 0, 0);
-        long timestamp = Math.min(Math.max(calendar.getTimeInMillis(), minDate), maxDate);
-        calendar.setTimeInMillis(timestamp);
-        if (datePicker.getYear() != calendar.get(Calendar.YEAR) || datePicker.getMonth() != calendar.get(Calendar.MONTH) || datePicker.getDayOfMonth() != calendar.get(Calendar.DAY_OF_MONTH)) {
-          datePicker.updateDate(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH));
-        }
-      });
-    }
-
-    if (args.containsKey(RNConstants.ARG_TESTID)) {
-      datePicker.setTag(args.getString(RNConstants.ARG_TESTID));
-    }
-
-    return dialog;
-  }
-
-  @Override
-  public void onDismiss(@NonNull DialogInterface dialog) {
-    super.onDismiss(dialog);
-    if (mOnDismissListener != null) {
-      mOnDismissListener.onDismiss(dialog);
-    }
-  }
-
-  /*package*/ void setOnDateSetListener(@Nullable OnDateSetListener onDateSetListener) {
-    mOnDateSetListener = onDateSetListener;
-  }
-
-  /*package*/ void setOnDismissListener(@Nullable OnDismissListener onDismissListener) {
-    mOnDismissListener = onDismissListener;
-  }
-
-  /*package*/ void setOnNeutralButtonActionListener(@Nullable OnClickListener onNeutralButtonActionListener) {
-    mOnNeutralButtonActionListener = onNeutralButtonActionListener;
-  }
-}
+     if (args != null) {
+       setButtonTitles(args, dialog, mOnNeutralButtonActionListener);
+       if (activityContext != null) {
+         RNDatePickerDisplay display = getDisplayDate(args);
+         boolean needsColorOverride = display == RNDatePickerDisplay.SPINNER;
+         dialog.setOnShowListener(setButtonTextColor(activityContext, dialog, args, needsColorOverride));
+       }
+     }
+ 
+     final DatePicker datePicker = dialog.getDatePicker();
+     final long minDate = Common.minDateWithTimeZone(args);
+     final long maxDate = Common.maxDateWithTimeZone(args);
+ 
+     if (args.containsKey(RNConstants.ARG_MINDATE)) {
+       datePicker.setMinDate(minDate);
+     } else {
+       // This is to work around a bug in DatePickerDialog where it doesn't display a title showing
+       // the date under certain conditions.
+       datePicker.setMinDate(RNConstants.DEFAULT_MIN_DATE);
+     }
+     
+     if (args.containsKey(RNConstants.FIRST_DAY_OF_WEEK)) {
+       final int firstDayOfWeek = args.getInt(RNConstants.FIRST_DAY_OF_WEEK);
+       datePicker.setFirstDayOfWeek(firstDayOfWeek);
+     }
+ 
+     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && (args.containsKey(RNConstants.ARG_MAXDATE) || args.containsKey(RNConstants.ARG_MINDATE))) {
+       datePicker.setOnDateChangedListener((view, year, monthOfYear, dayOfMonth) -> {
+         Calendar calendar = Calendar.getInstance(Common.getTimeZone(args));
+         calendar.set(year, monthOfYear, dayOfMonth, 0, 0, 0);
+         long timestamp = Math.min(Math.max(calendar.getTimeInMillis(), minDate), maxDate);
+         calendar.setTimeInMillis(timestamp);
+         if (datePicker.getYear() != calendar.get(Calendar.YEAR) || datePicker.getMonth() != calendar.get(Calendar.MONTH) || datePicker.getDayOfMonth() != calendar.get(Calendar.DAY_OF_MONTH)) {
+           datePicker.updateDate(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH));
+         }
+       });
+     }
+ 
+     if (args.containsKey(RNConstants.ARG_TESTID)) {
+       datePicker.setTag(args.getString(RNConstants.ARG_TESTID));
+     }
+ 
+     return dialog;
+   }
+ 
+   @Override
+   public void onDismiss(@NonNull DialogInterface dialog) {
+     super.onDismiss(dialog);
+     if (mOnDismissListener != null) {
+       mOnDismissListener.onDismiss(dialog);
+     }
+   }
+ 
+   /*package*/ void setOnDateSetListener(@Nullable OnDateSetListener onDateSetListener) {
+     mOnDateSetListener = onDateSetListener;
+   }
+ 
+   /*package*/ void setOnDismissListener(@Nullable OnDismissListener onDismissListener) {
+     mOnDismissListener = onDismissListener;
+   }
+ 
+   /*package*/ void setOnNeutralButtonActionListener(@Nullable OnClickListener onNeutralButtonActionListener) {
+     mOnNeutralButtonActionListener = onNeutralButtonActionListener;
+   }
+ }
+ 

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
@@ -117,7 +117,8 @@ public class RNDatePickerDialogFragment extends DialogFragment {
       datePicker.setMinDate(RNConstants.DEFAULT_MIN_DATE);
     }
     
-    if (args.containsKey(RNConstants.FIRST_DAY_OF_WEEK)) {
+    // Only compatible with SDK 21 and above
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && args.containsKey(RNConstants.FIRST_DAY_OF_WEEK)) {
       final int firstDayOfWeek = args.getInt(RNConstants.FIRST_DAY_OF_WEEK);
       datePicker.setFirstDayOfWeek(firstDayOfWeek);
     }

--- a/example/App.js
+++ b/example/App.js
@@ -168,7 +168,7 @@ export const App = () => {
         : `${item} mins`
       : item;
     return (
-      <View style={{marginHorizontal: 1}}>
+      <View style={{marginHorizontal: 1}} testID={`${item}`}>
         <Button
           title={title || 'undefined'}
           onPress={() => {

--- a/example/App.js
+++ b/example/App.js
@@ -351,13 +351,7 @@ export const App = () => {
             <ThemedText style={styles.textLabel}>
               firstDayOfWeek (android only)
             </ThemedText>
-            <View
-              style={{
-                flexDirection: 'row',
-                justifyContent: 'center',
-                flexWrap: 'wrap',
-                gap: 5,
-              }}>
+            <View style={styles.firstDayOfWeekContainer}>
               <Button
                 title={'Sunday'}
                 value={DAY_OF_WEEK.Sunday}
@@ -693,6 +687,12 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingTop: 10,
     width: 350,
+  },
+  firstDayOfWeekContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    flexWrap: 'wrap',
+    gap: 5,
   },
 });
 

--- a/example/App.js
+++ b/example/App.js
@@ -180,6 +180,20 @@ export const App = () => {
     );
   };
 
+  const renderDayOfWeekItem = ({item}) => {
+    const key = item[0];
+    const value = item[1];
+    return (
+      <View style={{marginHorizontal: 1}} testID={`${key}`}>
+        <Button
+          title={`${key}`}
+          value={value}
+          onPress={() => setFirstDayOfWeek(value)}
+        />
+      </View>
+    );
+  };
+
   const toggleMinMaxDateInUTC = () => {
     setTzOffsetInMinutes(0);
     setTzName(undefined);
@@ -352,40 +366,12 @@ export const App = () => {
               firstDayOfWeek (android only)
             </ThemedText>
             <View style={styles.firstDayOfWeekContainer}>
-              <Button
-                title={'Sunday'}
-                value={DAY_OF_WEEK.Sunday}
-                onPress={() => setFirstDayOfWeek(DAY_OF_WEEK.Sunday)}
-              />
-              <Button
-                title={'Monday'}
-                value={DAY_OF_WEEK.Monday}
-                onPress={() => setFirstDayOfWeek(DAY_OF_WEEK.Monday)}
-              />
-              <Button
-                title={'Tuesday'}
-                value={DAY_OF_WEEK.Tuesday}
-                onPress={() => setFirstDayOfWeek(DAY_OF_WEEK.Tuesday)}
-              />
-              <Button
-                title={'Wednesday'}
-                value={DAY_OF_WEEK.Wednesday}
-                onPress={() => setFirstDayOfWeek(DAY_OF_WEEK.Wednesday)}
-              />
-              <Button
-                title={'Thursday'}
-                value={DAY_OF_WEEK.Thursday}
-                onPress={() => setFirstDayOfWeek(DAY_OF_WEEK.Thursday)}
-              />
-              <Button
-                title={'Friday'}
-                value={DAY_OF_WEEK.Friday}
-                onPress={() => setFirstDayOfWeek(DAY_OF_WEEK.Friday)}
-              />
-              <Button
-                title={'Saturday'}
-                value={DAY_OF_WEEK.Saturday}
-                onPress={() => setFirstDayOfWeek(DAY_OF_WEEK.Saturday)}
+              <FlatList
+                testID="firstDayOfWeekSelector"
+                style={{marginBottom: 10}}
+                horizontal={true}
+                renderItem={renderDayOfWeekItem}
+                data={Object.entries(DAY_OF_WEEK)}
               />
             </View>
           </View>

--- a/example/App.js
+++ b/example/App.js
@@ -111,7 +111,7 @@ export const App = () => {
   const [maxDate] = useState(new Date('2021'));
   const [minDate] = useState(new Date('2018'));
   const [is24Hours, set24Hours] = useState(false);
-  const [firstDayOfWeek, setFirstDayOfWeek] = useState(DAY_OF_WEEK.Monday);
+  const [firstDayOfWeek, setFirstDayOfWeek] = useState(DAY_OF_WEEK.Sunday);
   const [dateFormat, setDateFormat] = useState('longdate');
   const [dayOfWeekFormat, setDayOfWeekFormat] = useState(
     '{dayofweek.abbreviated(2)}',

--- a/example/App.js
+++ b/example/App.js
@@ -253,6 +253,13 @@ export const App = () => {
                 />
               </>
             )}
+            <Info
+              testID={'firstDayOfWeek'}
+              title={'First Day of Week:'}
+              body={`${Object.keys(DAY_OF_WEEK).find(
+                (key) => DAY_OF_WEEK[key] === firstDayOfWeek,
+              )}`}
+            />
           </View>
         </View>
         <ScrollView
@@ -334,6 +341,60 @@ export const App = () => {
               testID="neutralButtonLabelTextInput"
             />
           </View>
+
+          <View
+            style={{
+              flexDirection: 'column',
+              flexWrap: 'wrap',
+              paddingBottom: 10,
+            }}>
+            <ThemedText style={styles.textLabel}>
+              firstDayOfWeek (android only)
+            </ThemedText>
+            <View
+              style={{
+                flexDirection: 'row',
+                justifyContent: 'center',
+                flexWrap: 'wrap',
+              }}>
+              <Button
+                title={'Sunday'}
+                value={DAY_OF_WEEK.Sunday}
+                onPress={() => setFirstDayOfWeek(DAY_OF_WEEK.Sunday)}
+              />
+              <Button
+                title={'Monday'}
+                value={DAY_OF_WEEK.Monday}
+                onPress={() => setFirstDayOfWeek(DAY_OF_WEEK.Monday)}
+              />
+              <Button
+                title={'Tuesday'}
+                value={DAY_OF_WEEK.Tuesday}
+                onPress={() => setFirstDayOfWeek(DAY_OF_WEEK.Tuesday)}
+              />
+              <Button
+                title={'Wednesday'}
+                value={DAY_OF_WEEK.Wednesday}
+                onPress={() => setFirstDayOfWeek(DAY_OF_WEEK.Wednesday)}
+              />
+              <Button
+                title={'Thursday'}
+                value={DAY_OF_WEEK.Thursday}
+                onPress={() => setFirstDayOfWeek(DAY_OF_WEEK.Thursday)}
+              />
+              <Button
+                title={'Friday'}
+                value={DAY_OF_WEEK.Friday}
+                onPress={() => setFirstDayOfWeek(DAY_OF_WEEK.Friday)}
+              />
+              <Button
+                title={'Saturday'}
+                value={DAY_OF_WEEK.Saturday}
+                onPress={() => setFirstDayOfWeek(DAY_OF_WEEK.Saturday)}
+              />
+            </View>
+          </View>
+
           <View style={styles.header}>
             <ThemedText style={styles.textLabel}>
               [android] show and dismiss picker after 3 secs
@@ -410,6 +471,7 @@ export const App = () => {
                 neutralButton={{label: neutralButtonLabel}}
                 negativeButton={{label: 'Cancel', textColor: 'red'}}
                 disabled={disabled}
+                firstDayOfWeek={firstDayOfWeek}
               />
             )}
           </View>

--- a/example/App.js
+++ b/example/App.js
@@ -356,6 +356,7 @@ export const App = () => {
                 flexDirection: 'row',
                 justifyContent: 'center',
                 flexWrap: 'wrap',
+                gap: 5,
               }}>
               <Button
                 title={'Sunday'}

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -174,7 +174,7 @@ describe('e2e tests', () => {
 
       await waitFor(elementByText(timeZone)).toBeVisible().withTimeout(1000);
 
-      await elementByText(timeZone).tap();
+      await elementByText(timeZone).multiTap(2);
 
       await assertTimeLabels({
         utcTime: '2021-11-13T01:00:00Z',
@@ -197,7 +197,7 @@ describe('e2e tests', () => {
 
       await waitFor(elementByText(timeZone)).toBeVisible().withTimeout(1000);
 
-      await elementByText(timeZone).tap();
+      await elementByText(timeZone).multiTap(2);
 
       await userOpensPicker({mode: 'date', display: getPickerDisplay()});
 
@@ -274,6 +274,8 @@ describe('e2e tests', () => {
       if (isAndroid()) {
         tzOffsetPreset = tzOffsetPreset.toUpperCase();
       }
+
+      await elementById('DateTimePickerScrollView').scrollTo('top');
 
       await userOpensPicker({
         mode: 'time',

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -12,6 +12,7 @@ const {
   userOpensPicker,
   userTapsCancelButtonAndroid,
   userTapsOkButtonAndroid,
+  userSelectsDayInCalendar,
 } = require('./utils/actions');
 const {isIOS, isAndroid, wait, Platform} = require('./utils/utils');
 const {device} = require('detox');
@@ -467,64 +468,45 @@ describe('e2e tests', () => {
   });
 
   describe(':android: firstDayOfWeek functionality', () => {
-    it(':android: picker should have Sunday as firstDayOfWeek and select Sunday date', async () => {
-      const targetDate = '2021-11-07T01:00:00Z';
-      const targetDateWithTZ = '2021-11-07T02:00:00+01:00';
+    it.each([
+      {
+        firstDayOfWeekIn: 'Sunday',
+        selectDayPositions: {xPosIn: -2, yPosIn: 4},
+      },
+      {
+        firstDayOfWeekIn: 'Tuesday',
+        selectDayPositions: {xPosIn: 3, yPosIn: 3},
+      },
+    ])(
+      ':android: picker should have $firstDayOfWeekIn as firstDayOfWeek and select Sunday date',
+      async ({firstDayOfWeekIn, selectDayPositions}) => {
+        const targetDate = '2021-11-07T01:00:00Z';
+        const targetDateWithTZ = '2021-11-07T02:00:00+01:00';
 
-      await userOpensPicker({mode: 'date', display: getPickerDisplay()});
-      await expect(getDatePickerAndroid()).toBeVisible();
+        await userOpensPicker({
+          mode: 'date',
+          display: getPickerDisplay(),
+          firstDayOfWeek: firstDayOfWeekIn,
+        });
+        await expect(getDatePickerAndroid()).toBeVisible();
 
-      const uiDevice = device.getUiDevice();
-      const focusSeventhOfNovemberInCalendar = async () => {
-        for (let i = 0; i < 4; i++) {
-          await uiDevice.pressDPadDown();
-        }
-        for (let i = 0; i < 2; i++) {
-          await uiDevice.pressDPadLeft();
-        }
-      };
-      await focusSeventhOfNovemberInCalendar();
-      await uiDevice.pressEnter();
-      await userTapsOkButtonAndroid();
+        const uiDevice = device.getUiDevice();
+        await userSelectsDayInCalendar(uiDevice, {
+          xPos: selectDayPositions.xPosIn,
+          yPos: selectDayPositions.yPosIn,
+        });
 
-      await expect(elementById('firstDayOfWeek')).toHaveText('Sunday');
+        await userTapsOkButtonAndroid();
 
-      await assertTimeLabels({
-        utcTime: targetDate,
-        deviceTime: targetDateWithTZ,
-      });
-    });
+        await expect(elementById('firstDayOfWeek')).toHaveText(
+          firstDayOfWeekIn,
+        );
 
-    it(':android: should select firstDayOfWeek as Tuesday and select the Sunday date', async () => {
-      const targetDate = '2021-11-07T01:00:00Z';
-      const targetDateWithTZ = '2021-11-07T02:00:00+01:00';
-
-      await userOpensPicker({
-        mode: 'date',
-        display: getPickerDisplay(),
-        firstDayOfWeek: 'TUESDAY',
-      });
-      await expect(getDatePickerAndroid()).toBeVisible();
-
-      const uiDevice = device.getUiDevice();
-      const focusSeventhOfNovemberInCalendar = async () => {
-        for (let i = 0; i < 3; i++) {
-          await uiDevice.pressDPadDown();
-        }
-        for (let i = 0; i < 3; i++) {
-          await uiDevice.pressDPadRight();
-        }
-      };
-      await focusSeventhOfNovemberInCalendar();
-      await uiDevice.pressEnter();
-      await userTapsOkButtonAndroid();
-
-      await expect(elementById('firstDayOfWeek')).toHaveText('Tuesday');
-
-      await assertTimeLabels({
-        utcTime: targetDate,
-        deviceTime: targetDateWithTZ,
-      });
-    });
+        await assertTimeLabels({
+          utcTime: targetDate,
+          deviceTime: targetDateWithTZ,
+        });
+      },
+    );
   });
 });

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -165,9 +165,15 @@ describe('e2e tests', () => {
 
       await expect(elementById('overriddenTzName')).toHaveText('Europe/Prague');
 
-      await elementById('timezone').swipe('left', 'fast', 0.5);
+      await elementById('DateTimePickerScrollView').scrollTo('bottom');
 
       let timeZone = 'America/Vancouver';
+      await waitFor(elementById('timezone')).toBeVisible().withTimeout(1000);
+      await waitFor(elementById(timeZone))
+        .toBeVisible()
+        .whileElement(by.id('timezone'))
+        .scroll(200, 'right');
+
       if (isAndroid()) {
         timeZone = timeZone.toUpperCase();
       }
@@ -188,9 +194,15 @@ describe('e2e tests', () => {
     });
 
     it('daylight saving should work properly', async () => {
-      await elementById('timezone').swipe('left', 'fast', 0.5);
+      await elementById('DateTimePickerScrollView').scrollTo('bottom');
 
       let timeZone = 'America/Vancouver';
+      await waitFor(elementById('timezone')).toBeVisible().withTimeout(1000);
+      await waitFor(elementById(timeZone))
+        .toBeVisible()
+        .whileElement(by.id('timezone'))
+        .scroll(200, 'right');
+
       if (isAndroid()) {
         timeZone = timeZone.toUpperCase();
       }
@@ -228,6 +240,7 @@ describe('e2e tests', () => {
         await uiDevice.pressEnter();
         await userTapsOkButtonAndroid();
 
+        await elementById('DateTimePickerScrollView').scrollTo('top');
         await userOpensPicker({mode: 'time', display: getPickerDisplay()});
         await userChangesTimeValue({hours: '2', minutes: '0'});
         await userTapsOkButtonAndroid();

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -5,13 +5,13 @@ const {
   getDatePickerAndroid,
   getDateTimePickerControlIOS,
   getInlineTimePickerIOS,
+  getDatePickerButtonIOS,
 } = require('./utils/matchers');
 const {
   userChangesTimeValue,
   userOpensPicker,
   userTapsCancelButtonAndroid,
   userTapsOkButtonAndroid,
-  userDismissesCompactDatePicker,
 } = require('./utils/actions');
 const {isIOS, isAndroid, wait, Platform} = require('./utils/utils');
 const {device} = require('detox');
@@ -63,15 +63,15 @@ describe('e2e tests', () => {
     await userOpensPicker({mode: 'date', display: 'default'});
 
     if (isIOS()) {
-      await element(
-        by.traits(['staticText']).withAncestor(by.label('Date Picker')),
-      ).tap();
+      await elementById('DateTimePickerScrollView').scrollTo('bottom');
+      await getDatePickerButtonIOS().tap();
+
       // 'label' maps to 'description' in view hierarchy debugger
       const nextMonthArrow = element(by.label('Next Month'));
 
       await nextMonthArrow.tap();
       await nextMonthArrow.tap();
-      await userDismissesCompactDatePicker();
+      await getDatePickerButtonIOS().tap();
     } else {
       const calendarHorizontalScrollView = element(
         by

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -447,4 +447,66 @@ describe('e2e tests', () => {
       });
     });
   });
+
+  describe(':android: firstDayOfWeek functionality', () => {
+    it(':android: picker should have Sunday as firstDayOfWeek and select Sunday date', async () => {
+      const targetDate = '2021-11-07T01:00:00Z';
+      const targetDateWithTZ = '2021-11-07T02:00:00+01:00';
+
+      await userOpensPicker({mode: 'date', display: getPickerDisplay()});
+      await expect(getDatePickerAndroid()).toBeVisible();
+
+      const uiDevice = device.getUiDevice();
+      const focusSeventhOfNovemberInCalendar = async () => {
+        for (let i = 0; i < 4; i++) {
+          await uiDevice.pressDPadDown();
+        }
+        for (let i = 0; i < 2; i++) {
+          await uiDevice.pressDPadLeft();
+        }
+      };
+      await focusSeventhOfNovemberInCalendar();
+      await uiDevice.pressEnter();
+      await userTapsOkButtonAndroid();
+
+      await expect(elementById('firstDayOfWeek')).toHaveText('Sunday');
+
+      await assertTimeLabels({
+        utcTime: targetDate,
+        deviceTime: targetDateWithTZ,
+      });
+    });
+
+    it(':android: should select firstDayOfWeek as Tuesday and select the Sunday date', async () => {
+      const targetDate = '2021-11-07T01:00:00Z';
+      const targetDateWithTZ = '2021-11-07T02:00:00+01:00';
+
+      await userOpensPicker({
+        mode: 'date',
+        display: getPickerDisplay(),
+        firstDayOfWeek: 'TUESDAY',
+      });
+      await expect(getDatePickerAndroid()).toBeVisible();
+
+      const uiDevice = device.getUiDevice();
+      const focusSeventhOfNovemberInCalendar = async () => {
+        for (let i = 0; i < 3; i++) {
+          await uiDevice.pressDPadDown();
+        }
+        for (let i = 0; i < 3; i++) {
+          await uiDevice.pressDPadRight();
+        }
+      };
+      await focusSeventhOfNovemberInCalendar();
+      await uiDevice.pressEnter();
+      await userTapsOkButtonAndroid();
+
+      await expect(elementById('firstDayOfWeek')).toHaveText('Tuesday');
+
+      await assertTimeLabels({
+        utcTime: targetDate,
+        deviceTime: targetDateWithTZ,
+      });
+    });
+  });
 });

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -119,9 +119,11 @@ describe('e2e tests', () => {
       ios: 'inline',
       android: 'default',
     });
+    await elementById('DateTimePickerScrollView').scrollTo('top');
     await userOpensPicker({mode: 'time', display});
 
     if (isIOS()) {
+      await elementById('DateTimePickerScrollView').scrollTo('bottom');
       await expect(getInlineTimePickerIOS()).toBeVisible();
     } else {
       await expect(element(by.type('android.widget.TimePicker'))).toBeVisible();
@@ -211,6 +213,7 @@ describe('e2e tests', () => {
 
       await elementByText(timeZone).multiTap(2);
 
+      await elementById('DateTimePickerScrollView').scrollTo('top');
       await userOpensPicker({mode: 'date', display: getPickerDisplay()});
 
       if (isIOS()) {
@@ -325,7 +328,9 @@ describe('e2e tests', () => {
         await expect(elementById('utcTime')).toHaveText('2021-11-13T00:00:00Z');
 
         // Ensure you can select tomorrow (iOS)
+        await elementById('DateTimePickerScrollView').scrollTo('top');
         await userOpensPicker({mode: 'date', display: getPickerDisplay()});
+        await elementById('DateTimePickerScrollView').scrollTo('bottom');
         await testElement.setDatePickerDate('2021-11-14T01:00:00Z', 'ISO8601');
       } else {
         const uiDevice = device.getUiDevice();

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -13,6 +13,7 @@ const {
   userTapsCancelButtonAndroid,
   userTapsOkButtonAndroid,
   userSelectsDayInCalendar,
+  userSwipesTimezoneListUntilDesiredIsVisible,
 } = require('./utils/actions');
 const {isIOS, isAndroid, wait, Platform} = require('./utils/utils');
 const {device} = require('detox');
@@ -172,10 +173,7 @@ describe('e2e tests', () => {
 
       let timeZone = 'America/Vancouver';
       await waitFor(elementById('timezone')).toBeVisible().withTimeout(1000);
-      await waitFor(elementById(timeZone))
-        .toBeVisible()
-        .whileElement(by.id('timezone'))
-        .scroll(200, 'right');
+      await userSwipesTimezoneListUntilDesiredIsVisible(timeZone);
 
       if (isAndroid()) {
         timeZone = timeZone.toUpperCase();
@@ -201,10 +199,7 @@ describe('e2e tests', () => {
 
       let timeZone = 'America/Vancouver';
       await waitFor(elementById('timezone')).toBeVisible().withTimeout(1000);
-      await waitFor(elementById(timeZone))
-        .toBeVisible()
-        .whileElement(by.id('timezone'))
-        .scroll(200, 'right');
+      await userSwipesTimezoneListUntilDesiredIsVisible(timeZone);
 
       if (isAndroid()) {
         timeZone = timeZone.toUpperCase();

--- a/example/e2e/utils/actions.js
+++ b/example/e2e/utils/actions.js
@@ -65,14 +65,9 @@ async function userTapsOkButtonAndroid() {
   await okButton.tap();
 }
 
-async function userDismissesCompactDatePicker() {
-  await element(by.type('_UIDatePickerContainerView')).tap();
-}
-
 module.exports = {
   userOpensPicker,
   userTapsCancelButtonAndroid,
   userTapsOkButtonAndroid,
   userChangesTimeValue,
-  userDismissesCompactDatePicker,
 };

--- a/example/e2e/utils/actions.js
+++ b/example/e2e/utils/actions.js
@@ -23,7 +23,13 @@ async function userChangesTimeValue(
   }
 }
 
-async function userOpensPicker({mode, display, interval, tzOffsetPreset}) {
+async function userOpensPicker({
+  mode,
+  display,
+  interval,
+  tzOffsetPreset,
+  firstDayOfWeek,
+}) {
   await element(by.text(mode)).tap();
   await element(by.text(display)).tap();
   if (interval) {
@@ -31,6 +37,9 @@ async function userOpensPicker({mode, display, interval, tzOffsetPreset}) {
   }
   if (tzOffsetPreset) {
     await element(by.text(tzOffsetPreset)).tap();
+  }
+  if (firstDayOfWeek) {
+    await element(by.text(firstDayOfWeek)).tap();
   }
   await element(by.id('showPickerButton')).tap();
 }

--- a/example/e2e/utils/actions.js
+++ b/example/e2e/utils/actions.js
@@ -71,6 +71,13 @@ async function userTapsOkButtonAndroid() {
   await okButton.tap();
 }
 
+async function userSwipesTimezoneListUntilDesiredIsVisible(timeZone) {
+  await waitFor(elementById(timeZone))
+    .toBeVisible()
+    .whileElement(by.id('timezone'))
+    .scroll(200, 'right');
+}
+
 // Helper function to select a day in the calendar
 // A negative number xPos and yPos means we go left and up respectively
 // A positive number xPos and yPos means we go right and down respectively
@@ -92,4 +99,5 @@ module.exports = {
   userTapsOkButtonAndroid,
   userChangesTimeValue,
   userSelectsDayInCalendar,
+  userSwipesTimezoneListUntilDesiredIsVisible,
 };

--- a/example/e2e/utils/actions.js
+++ b/example/e2e/utils/actions.js
@@ -1,3 +1,5 @@
+const {elementById} = require('./matchers');
+
 async function userChangesTimeValue(
   {hours, minutes} = {hours: undefined, minutes: undefined},
 ) {
@@ -36,7 +38,9 @@ async function userOpensPicker({
     await element(by.text(String(interval))).tap();
   }
   if (tzOffsetPreset) {
+    await elementById('DateTimePickerScrollView').scrollTo('bottom');
     await element(by.text(tzOffsetPreset)).tap();
+    await elementById('DateTimePickerScrollView').scrollTo('top');
   }
   if (firstDayOfWeek) {
     await element(by.text(firstDayOfWeek)).tap();

--- a/example/e2e/utils/actions.js
+++ b/example/e2e/utils/actions.js
@@ -45,7 +45,7 @@ async function userOpensPicker({
     await elementById('DateTimePickerScrollView').scrollTo('top');
   }
   if (firstDayOfWeek) {
-    await element(by.text(firstDayOfWeek)).tap();
+    await element(by.id(firstDayOfWeek)).tap();
   }
   await element(by.id('showPickerButton')).tap();
 }
@@ -71,9 +71,25 @@ async function userTapsOkButtonAndroid() {
   await okButton.tap();
 }
 
+// Helper function to select a day in the calendar
+// A negative number xPos and yPos means we go left and up respectively
+// A positive number xPos and yPos means we go right and down respectively
+async function userSelectsDayInCalendar(uiDevice, {xPos, yPos}) {
+  for (let i = 0; i < Math.abs(yPos); i++) {
+    yPos < 0 ? await uiDevice.pressDPadUp(i) : await uiDevice.pressDPadDown(i);
+  }
+  for (let j = 0; j < Math.abs(xPos); j++) {
+    xPos < 0
+      ? await uiDevice.pressDPadLeft(j)
+      : await uiDevice.pressDPadRight(j);
+  }
+  await uiDevice.pressEnter();
+}
+
 module.exports = {
   userOpensPicker,
   userTapsCancelButtonAndroid,
   userTapsOkButtonAndroid,
   userChangesTimeValue,
+  userSelectsDayInCalendar,
 };

--- a/example/e2e/utils/actions.js
+++ b/example/e2e/utils/actions.js
@@ -32,6 +32,8 @@ async function userOpensPicker({
   tzOffsetPreset,
   firstDayOfWeek,
 }) {
+  await elementById('DateTimePickerScrollView').scrollTo('top');
+
   await element(by.text(mode)).tap();
   await element(by.text(display)).tap();
   if (interval) {

--- a/example/e2e/utils/matchers.js
+++ b/example/e2e/utils/matchers.js
@@ -10,6 +10,8 @@ const getDateTimePickerControlIOS = () => element(by.type('UIDatePicker'));
 
 const getDatePickerAndroid = () => element(by.id('dateTimePicker'));
 
+const getDatePickerButtonIOS = () => element(by.id('dateTimePicker'));
+
 module.exports = {
   elementById,
   elementByText,
@@ -17,4 +19,5 @@ module.exports = {
   getDateTimePickerControlIOS,
   getDatePickerAndroid,
   getInlineTimePickerIOS,
+  getDatePickerButtonIOS,
 };

--- a/src/DateTimePickerAndroid.android.js
+++ b/src/DateTimePickerAndroid.android.js
@@ -42,6 +42,7 @@ function open(props: AndroidNativeProps) {
     positiveButtonLabel,
     negativeButtonLabel,
     testID,
+    firstDayOfWeek,
   } = props;
   validateAndroidProps(props);
   invariant(originalValue, 'A date or time must be specified as `value` prop.');
@@ -84,6 +85,7 @@ function open(props: AndroidNativeProps) {
         timeZoneName,
         dialogButtons,
         testID,
+        firstDayOfWeek,
       });
 
       switch (action) {

--- a/src/androidUtils.js
+++ b/src/androidUtils.js
@@ -26,6 +26,7 @@ type OpenParams = {
   timeZoneOffsetInMinutes: AndroidNativeProps['timeZoneOffsetInMinutes'],
   timeZoneName: AndroidNativeProps['timeZoneName'],
   testID: AndroidNativeProps['testID'],
+  firstDayOfWeek: AndroidNativeProps['firstDayOfWeek'],
   dialogButtons: {
     positive: ProcessedButton,
     negative: ProcessedButton,
@@ -70,6 +71,7 @@ function getOpenPicker(
         timeZoneName,
         dialogButtons,
         testID,
+        firstDayOfWeek,
       }: OpenParams) =>
         // $FlowFixMe - `AbstractComponent` [1] is not an instance type.
         pickers[ANDROID_MODE.date].open({
@@ -81,6 +83,7 @@ function getOpenPicker(
           timeZoneName,
           dialogButtons,
           testID,
+          firstDayOfWeek,
         });
   }
 }

--- a/src/datetimepicker.android.js
+++ b/src/datetimepicker.android.js
@@ -32,6 +32,7 @@ export default function RNDateTimePickerAndroid(
     negativeButtonLabel,
     neutralButtonLabel,
     testID,
+    firstDayOfWeek,
   } = props;
   const valueTimestamp = value.getTime();
 
@@ -62,6 +63,7 @@ export default function RNDateTimePickerAndroid(
         negativeButtonLabel,
         neutralButtonLabel,
         testID,
+        firstDayOfWeek,
       };
       DateTimePickerAndroid.open(params);
     },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -168,7 +168,7 @@ export type AndroidNativeProps = Readonly<
        * */
       negativeButtonLabel?: string;
       /**
-       * Sets the first day of the week shown in the calendar. Defaults to DAY_OF_WEEK.Sunday
+       * Sets the first day of the week shown in the calendar
        */
       firstDayOfWeek?: DAY_OF_WEEK;
       /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -167,11 +167,13 @@ export type AndroidNativeProps = Readonly<
        * @deprecated use negativeButton instead
        * */
       negativeButtonLabel?: string;
-
+      /**
+       * Sets the first day of the week shown in the calendar. Defaults to DAY_OF_WEEK.Sunday
+       */
+      firstDayOfWeek?: DAY_OF_WEEK;
       /**
        * callback when an error occurs inside the date picker native code (such as null activity)
        */
-      firstDayOfWeek?: DAY_OF_WEEK;
       onError?: (arg: Error) => void;
     }
 >;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -171,6 +171,7 @@ export type AndroidNativeProps = Readonly<
       /**
        * callback when an error occurs inside the date picker native code (such as null activity)
        */
+      firstDayOfWeek?: DAY_OF_WEEK;
       onError?: (arg: Error) => void;
     }
 >;

--- a/src/types.js
+++ b/src/types.js
@@ -206,7 +206,7 @@ export type AndroidNativeProps = $ReadOnly<{|
    * */
   negativeButtonLabel?: string,
   /**
-   * Sets the first day of the week shown in the calendar. Defaults to DAY_OF_WEEK.Sunday
+   * Sets the first day of the week shown in the calendar
    */
   firstDayOfWeek?: typeof DAY_OF_WEEK,
   onError?: (Error) => void,

--- a/src/types.js
+++ b/src/types.js
@@ -205,6 +205,9 @@ export type AndroidNativeProps = $ReadOnly<{|
    * @deprecated use negativeButton instead
    * */
   negativeButtonLabel?: string,
+  /**
+   * Sets the first day of the week shown in the calendar. Defaults to DAY_OF_WEEK.Sunday
+   */
   firstDayOfWeek?: typeof DAY_OF_WEEK,
   onError?: (Error) => void,
 |}>;

--- a/src/types.js
+++ b/src/types.js
@@ -205,6 +205,7 @@ export type AndroidNativeProps = $ReadOnly<{|
    * @deprecated use negativeButton instead
    * */
   negativeButtonLabel?: string,
+  firstDayOfWeek?: typeof DAY_OF_WEEK,
   onError?: (Error) => void,
 |}>;
 


### PR DESCRIPTION
# Summary

This feature provides the optional **firstDayOfWeek** functionality to the DatePicker on Android (currently only available in Windows). I was looking for tasks to get started with in the project and I saw this was a pending issue [#196](https://github.com/react-native-datetimepicker/datetimepicker/issues/196), so I decided to implement it.

Although the issue itself is quite old, hopefully it is still useful for someone.

### How did you implement the solution?

As suggested in the issue thread, https://developer.android.com/reference/android/widget/DatePicker#setFirstDayOfWeek(int) provides the functionality to the Android DatePicker so that is what was used to implement it. The rest was simply bridging the props from React Native component to Android. 

The `firstDayOfWeek` prop accepts the `DAY_OF_WEEK` constant to set the first day of the week.

NOTE: The `DAY_OF_WEEK` constant was used for consistency between the original Windows implementation and the new Android one. This does however mean that once the prop is parsed in the Android component it adds a +1 to it since the integers for setFirstDayOfWeek are 1-indexed instead of 0-indexed.

closes #196

## Test Plan

Some examples of the UI changes when selecting different firstDayOfWeek:

| firstDayOfWeek set to Sunday | firstDayOfWeek set to Wednesday |
| ------- | :---------: |
| ![Screenshot 2024-05-29 at 15 40 31](https://github.com/react-native-datetimepicker/datetimepicker/assets/125880121/8042b9cc-268a-45a1-8690-5fdec57e87c0) | ![Screenshot 2024-05-29 at 15 51 25](https://github.com/react-native-datetimepicker/datetimepicker/assets/125880121/31200b8e-4c15-49b7-a240-a79ca6f358e9) |

![Screenshot 2024-05-30 at 10 29 54](https://github.com/react-native-datetimepicker/datetimepicker/assets/125880121/8b527f76-a162-4e72-87aa-125d023650b2)
_(Ran e2e tests for release on an emulated Pixel 6 Pro with API 30 and phone TZ set to Prague)_

### What's required for testing (prerequisites)?

e2e tests have been added to the project checking the functionality. These detox tests are only run on Android.

### What are the steps to reproduce (after prerequisites)?

I have added a row of buttons to the example App which allow swapping the `firstDayOfWeek` for any day of the week. These are used in the e2e tests. I have also added a line to the upper info section of the example App which shows the current `firstDayOfWeek` value (defaults to Sunday).

## Comments

Some of the included changes modify existing e2e tests as they seem to have stopped working due to the UI changes done to the example App. Some of these changes include:

* Added scroll down/up to some tests depending on necessity due to added buttons pushing some content out of view.
* Added `.multiTap(2)` instead of `.tap()` to some tests as they occasionally failed. I suspect this is caused by the button trying to be tapped being inside a horizontal scrollview that doesn't finish scrolling before the tap on the button is triggered.

As a side note, I have seen that there are a few e2e tests that fail on iOS (even on master) when I test them locally, specifically those that use the `spinner` implementation of the `DateTimePicker`.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
- [X] I have added automated tests, either in JS or e2e tests, as applicable
