### PR TITLE
fix: Tests without scrolling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ jobs:
           command: yarn detox:ios:build:release
           name: build app with new arch
 
-
   e2e_release_ios:
     executor:
       name: rn/macos
@@ -59,7 +58,7 @@ jobs:
             HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
             HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null
       - rn/ios_simulator_start:
-          device: 'iPhone 14'
+          device: 'iPhone 15 Pro Max'
       # - rn/yarn_install
       - run:
           command: yarn install --immutable
@@ -67,8 +66,8 @@ jobs:
       - run:
           command: yarn bundle:ios
           name: bundle js
-#      - rn/pod_install:
-#          pod_install_directory: 'example/ios'
+      #      - rn/pod_install:
+      #          pod_install_directory: 'example/ios'
       - run:
           command: (cd example && npx pod-install)
           name: pod install
@@ -89,7 +88,7 @@ jobs:
     steps:
       - checkout
       - android/change-java-version:
-          java-version: 17 
+          java-version: 17
       - run:
           command: avdmanager list
           name: list avds
@@ -99,7 +98,7 @@ jobs:
       - android/create-avd:
           avd-name: TestingAVD
           system-image: system-images;android-29;default;x86
-          additional-args: --device pixel_3_xl
+          additional-args: --device pixel_6_pro
           install: true
           background: false
       - android/start-emulator:
@@ -108,7 +107,7 @@ jobs:
           wait-for-emulator: true
           disable-animations: true
           restore-gradle-cache-post-emulator-launch: false
-          post-emulator-launch-assemble-command: "pwd"
+          post-emulator-launch-assemble-command: 'pwd'
       #      - android/disable-animations
       - run:
           command: npm install --global yarn
@@ -128,7 +127,6 @@ jobs:
       - store_artifacts:
           path: ./artifacts
 
-
   new_arch_android_build_only:
     executor:
       name: android/android-machine
@@ -137,14 +135,14 @@ jobs:
     steps:
       - checkout
       - android/change-java-version:
-           java-version: 17 
+          java-version: 17
       - run:
           command: avdmanager list
           name: list avds
       - android/create-avd:
           avd-name: TestingAVD
           system-image: system-images;android-29;default;x86
-          additional-args: --device pixel_3_xl
+          additional-args: --device pixel_6_pro
           install: true
           background: false
       - android/start-emulator:
@@ -153,7 +151,7 @@ jobs:
           wait-for-emulator: true
           disable-animations: true
           restore-gradle-cache-post-emulator-launch: false
-          post-emulator-launch-assemble-command: "pwd"
+          post-emulator-launch-assemble-command: 'pwd'
       - run:
           command: npm install --global yarn
           name: install yarn

--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -9,7 +9,7 @@ module.exports = {
     simulator: {
       type: 'ios.simulator',
       device: {
-        type: 'iPhone 14',
+        type: 'iPhone 15 Pro Max',
       },
     },
     emulator: {

--- a/example/App.js
+++ b/example/App.js
@@ -336,7 +336,7 @@ export const App = () => {
               placeholder="accentColor"
             />
           </View>
-          <View style={{flex: 1, flexDirection: 'row'}}>
+          <View style={styles.header}>
             <ThemedText style={styles.textLabel}>
               disabled (iOS only)
             </ThemedText>
@@ -360,7 +360,7 @@ export const App = () => {
             style={{
               flexDirection: 'column',
               flexWrap: 'wrap',
-              paddingBottom: 10,
+              paddingBottom: 0,
             }}>
             <ThemedText style={styles.textLabel}>
               firstDayOfWeek (android only)
@@ -368,7 +368,7 @@ export const App = () => {
             <View style={styles.firstDayOfWeekContainer}>
               <FlatList
                 testID="firstDayOfWeekSelector"
-                style={{marginBottom: 10}}
+                style={{marginBottom: 5}}
                 horizontal={true}
                 renderItem={renderDayOfWeekItem}
                 data={Object.entries(DAY_OF_WEEK)}
@@ -647,7 +647,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
   textLabel: {
-    margin: 10,
+    marginHorizontal: 5,
     flex: 1,
   },
   textInput: {

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -65,7 +65,6 @@ describe('e2e tests', () => {
     await userOpensPicker({mode: 'date', display: 'default'});
 
     if (isIOS()) {
-      await elementById('DateTimePickerScrollView').scrollTo('bottom');
       await getDatePickerButtonIOS().tap();
 
       // 'label' maps to 'description' in view hierarchy debugger
@@ -121,11 +120,9 @@ describe('e2e tests', () => {
       ios: 'inline',
       android: 'default',
     });
-    await elementById('DateTimePickerScrollView').scrollTo('top');
     await userOpensPicker({mode: 'time', display});
 
     if (isIOS()) {
-      await elementById('DateTimePickerScrollView').scrollTo('bottom');
       await expect(getInlineTimePickerIOS()).toBeVisible();
     } else {
       await expect(element(by.type('android.widget.TimePicker'))).toBeVisible();
@@ -169,8 +166,6 @@ describe('e2e tests', () => {
 
       await expect(elementById('overriddenTzName')).toHaveText('Europe/Prague');
 
-      await elementById('DateTimePickerScrollView').scrollTo('bottom');
-
       let timeZone = 'America/Vancouver';
       await waitFor(elementById('timezone')).toBeVisible().withTimeout(1000);
       await userSwipesTimezoneListUntilDesiredIsVisible(timeZone);
@@ -195,8 +190,6 @@ describe('e2e tests', () => {
     });
 
     it('daylight saving should work properly', async () => {
-      await elementById('DateTimePickerScrollView').scrollTo('bottom');
-
       let timeZone = 'America/Vancouver';
       await waitFor(elementById('timezone')).toBeVisible().withTimeout(1000);
       await userSwipesTimezoneListUntilDesiredIsVisible(timeZone);
@@ -209,7 +202,6 @@ describe('e2e tests', () => {
 
       await elementByText(timeZone).multiTap(2);
 
-      await elementById('DateTimePickerScrollView').scrollTo('top');
       await userOpensPicker({mode: 'date', display: getPickerDisplay()});
 
       if (isIOS()) {
@@ -239,7 +231,6 @@ describe('e2e tests', () => {
         await uiDevice.pressEnter();
         await userTapsOkButtonAndroid();
 
-        await elementById('DateTimePickerScrollView').scrollTo('top');
         await userOpensPicker({mode: 'time', display: getPickerDisplay()});
         await userChangesTimeValue({hours: '2', minutes: '0'});
         await userTapsOkButtonAndroid();
@@ -287,8 +278,6 @@ describe('e2e tests', () => {
         tzOffsetPreset = tzOffsetPreset.toUpperCase();
       }
 
-      await elementById('DateTimePickerScrollView').scrollTo('top');
-
       await userOpensPicker({
         mode: 'time',
         display: getPickerDisplay(),
@@ -324,9 +313,7 @@ describe('e2e tests', () => {
         await expect(elementById('utcTime')).toHaveText('2021-11-13T00:00:00Z');
 
         // Ensure you can select tomorrow (iOS)
-        await elementById('DateTimePickerScrollView').scrollTo('top');
         await userOpensPicker({mode: 'date', display: getPickerDisplay()});
-        await elementById('DateTimePickerScrollView').scrollTo('bottom');
         await testElement.setDatePickerDate('2021-11-14T01:00:00Z', 'ISO8601');
       } else {
         const uiDevice = device.getUiDevice();

--- a/example/e2e/detoxTest.spec.js
+++ b/example/e2e/detoxTest.spec.js
@@ -14,6 +14,7 @@ const {
   userTapsOkButtonAndroid,
   userSelectsDayInCalendar,
   userSwipesTimezoneListUntilDesiredIsVisible,
+  userDismissesCompactDatePicker,
 } = require('./utils/actions');
 const {isIOS, isAndroid, wait, Platform} = require('./utils/utils');
 const {device} = require('detox');
@@ -72,7 +73,7 @@ describe('e2e tests', () => {
 
       await nextMonthArrow.tap();
       await nextMonthArrow.tap();
-      await getDatePickerButtonIOS().tap();
+      await userDismissesCompactDatePicker();
     } else {
       const calendarHorizontalScrollView = element(
         by

--- a/example/e2e/utils/actions.js
+++ b/example/e2e/utils/actions.js
@@ -93,6 +93,10 @@ async function userSelectsDayInCalendar(uiDevice, {xPos, yPos}) {
   await uiDevice.pressEnter();
 }
 
+async function userDismissesCompactDatePicker() {
+  await element(by.type('_UIDatePickerContainerView')).tap();
+}
+
 module.exports = {
   userOpensPicker,
   userTapsCancelButtonAndroid,
@@ -100,4 +104,5 @@ module.exports = {
   userChangesTimeValue,
   userSelectsDayInCalendar,
   userSwipesTimezoneListUntilDesiredIsVisible,
+  userDismissesCompactDatePicker,
 };


### PR DESCRIPTION
# Summary

This PR aims to fix the need for tests to contain scrolling to accommodate the recent changes to the example app's App.js file. This stems from a short conversation that took place in #902.

First off I have reverted the test changes done in #902, specifically those that added `scrollTo('bottom')` or `scrollTo('top')`. I then implemented some small styling changes to App.js that reduces the separation between the different inputs on the main screen. Lastly, I changed the test devices to an **iPhone 15 Pro Max** for iOS and a **Pixel 6 Pro** for Android, both of which are larger and provide enough space to show all elements of the test App without scrolling.

*Please note that for Android, we simply state the TestingAVD name in `.detoxrc`, which Im pretty sure does not change the actual test device used in CircleCI. This means that we would probably need to change the configured emulator for CircleCI, something I don't think I can do or at least can't see where...*

## Test Plan

#### Android Tests
![Screenshot 2024-06-04 at 10 56 01](https://github.com/react-native-datetimepicker/datetimepicker/assets/125880121/f7ae7715-32f2-45f9-8d58-16ec79bb40d5)
*Tested with Pixel 6 Pro API 30*

#### iOS Tests
![Screenshot 2024-06-04 at 11 43 54](https://github.com/react-native-datetimepicker/datetimepicker/assets/125880121/82f226d6-d367-4405-9909-eb383cf269d0)
*Tested with iPhone 15 Pro Max with iOS 17.5*

NOTE: It seems that while locally I am running iOS 17.5, CircleCI is running an iPhone14 with version 16.4. It would seem that the Native TimePicker varies between these two versions and causes the tests to fail with the later version of iOS... Not sure what we should do about this. Maybe choosing a specific version and adapting the tests to it might be the best course of action.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
