### PR TITLE
Fixed issue #907 TypeError: Cannot read property 'dismiss' of undefined

### DIFF
--- a/src/DateTimePickerAndroid.android.js
+++ b/src/DateTimePickerAndroid.android.js
@@ -118,7 +118,7 @@ function open(props: AndroidNativeProps) {
 
 function dismiss(mode: AndroidNativeProps['mode']): Promise<boolean> {
   // $FlowFixMe - `AbstractComponent` [1] is not an instance type.
-  return pickers[mode].dismiss();
+  return pickers[mode]?.dismiss();
 }
 
 export const DateTimePickerAndroid = {open, dismiss};


### PR DESCRIPTION
# Summary
The error was described in [this issue](https://github.com/react-native-datetimepicker/datetimepicker/issues/907)

* What issues does the pull request solve? it solves [this issue](https://github.com/react-native-datetimepicker/datetimepicker/issues/907)

## Test Plan

### What's required for testing? run the code below on android
```ts
                 <DateTimePicker
                        testID="dateTimePicker"
                        timeZoneOffsetInMinutes={0}
                        value={date}
                        mode={mode}
                        is24Hour={true}
                        display={Platform.OS === 'ios' ? 'inline' : 'default'}
                        onChange={onChange}
                        minimumDate={new Date()}
                    />
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ❌     |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
