### PR TITLE
Fixed Issue #935: Unable to select a date earlier than Unix epoch whe…

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java
@@ -183,12 +183,10 @@ public class Common {
   }
 
   public static long minDateWithTimeZone(Bundle args) {
-    if (!args.containsKey(RNConstants.ARG_MINDATE)) {
-      return 0;
-    }
-
     Calendar minDate = Calendar.getInstance(getTimeZone(args));
-    minDate.setTimeInMillis(args.getLong(RNConstants.ARG_MINDATE));
+    long minDateTimeInMillis = args.containsKey(RNConstants.ARG_MINDATE) ?  args.getLong(RNConstants.ARG_MINDATE) : RNConstants.DEFAULT_MIN_DATE;
+
+    minDate.setTimeInMillis(minDateTimeInMillis);
     minDate.set(Calendar.HOUR_OF_DAY, 0);
     minDate.set(Calendar.MINUTE, 0);
     minDate.set(Calendar.SECOND, 0);


### PR DESCRIPTION
…n only a maximum date is provided on Android

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
The error was described in https://github.com/react-native-datetimepicker/datetimepicker/issues/935

* What issues does the pull request solve? 
It solves https://github.com/react-native-datetimepicker/datetimepicker/issues/935
* What is the feature?

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
