### PR TITLE
Add compatibility with Expo SDK 52

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDateTimePickerPackage.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDateTimePickerPackage.java
@@ -1,58 +1,80 @@
 package com.reactcommunity.rndatetimepicker;
 
-
 import androidx.annotation.Nullable;
 
 import com.facebook.react.TurboReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.module.annotations.ReactModuleList;
 import com.facebook.react.module.model.ReactModuleInfo;
 import com.facebook.react.module.model.ReactModuleInfoProvider;
+import com.facebook.react.turbomodule.core.interfaces.TurboModule;
+import com.facebook.react.uimanager.ViewManager;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+@ReactModuleList(
+  nativeModules = {
+    DatePickerModule.class,
+    TimePickerModule.class,
+  }
+)
 public class RNDateTimePickerPackage extends TurboReactPackage {
+
+  @Override
+  public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+    return Arrays.<NativeModule>asList(
+      new DatePickerModule(reactContext),
+      new TimePickerModule(reactContext)
+    );
+  }
+
   @Nullable
   @Override
   public NativeModule getModule(String name, ReactApplicationContext reactContext) {
-    if (name.equals(DatePickerModule.NAME)) {
-      return new DatePickerModule(reactContext);
-    } else if (name.equals(TimePickerModule.NAME)) {
-      return new TimePickerModule(reactContext);
-    } else {
-      return null;
+    switch (name) {
+      case DatePickerModule.NAME:
+        return new DatePickerModule(reactContext);
+      case TimePickerModule.NAME:
+        return new TimePickerModule(reactContext);
+      default:
+        return null;
     }
   }
 
   @Override
   public ReactModuleInfoProvider getReactModuleInfoProvider() {
-    return () -> {
-      boolean isTurboModule = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED;
-      final Map<String, ReactModuleInfo> moduleInfos = new HashMap<>();
-      moduleInfos.put(
-        DatePickerModule.NAME,
-        new ReactModuleInfo(
-          DatePickerModule.NAME,
-          DatePickerModule.NAME,
-          false, // canOverrideExistingModule
-          false, // needsEagerInit
-          false, // hasConstants
-          false, // isCxxModule
-          isTurboModule // isTurboModule
-        ));
-      moduleInfos.put(
-        TimePickerModule.NAME,
-        new ReactModuleInfo(
-          TimePickerModule.NAME,
-          TimePickerModule.NAME,
-          false, // canOverrideExistingModule
-          false, // needsEagerInit
-          false, // hasConstants
-          false, // isCxxModule
-          isTurboModule // isTurboModule
-        ));
-      return moduleInfos;
+    return new ReactModuleInfoProvider() {
+      @Override
+      public Map<String, ReactModuleInfo> getReactModuleInfos() {
+        final Map<String, ReactModuleInfo> reactModuleInfoMap = new HashMap<>();
+        Class<? extends NativeModule>[] moduleList = new Class[] {
+          DatePickerModule.class,
+          TimePickerModule.class,
+        };
+
+        for (Class<? extends NativeModule> moduleClass : moduleList) {
+          ReactModule reactModule = moduleClass.getAnnotation(ReactModule.class);
+
+          reactModuleInfoMap.put(
+            reactModule.name(),
+            new ReactModuleInfo(
+              reactModule.name(),
+              moduleClass.getName(),
+              reactModule.canOverrideExistingModule(),
+              reactModule.needsEagerInit(),
+              reactModule.hasConstants(),
+              reactModule.isCxxModule(),
+              TurboModule.class.isAssignableFrom(moduleClass)
+            )
+          );
+        }
+        return reactModuleInfoMap;
+      }
     };
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! We appreciate your time in making improvements. Please use this template so reviewers can understand the impact of the code changes. -->

# Summary

<!--
Explain the **motivation** for making this change, including:

* What issues or goals does this pull request address? Tag any related issues.
* What is the feature or enhancement?
* What areas of the codebase are impacted?
-->

This PR updates RNDateTimePickerPackage for compatibility with Expo SDK 52. It modifies createNativeModules to match Expo's recommended patterns and adjusts ReactModuleInfoProvider to improve dynamic handling of module information.

Expo PR: [link](https://github.com/expo/expo/pull/32803)

## Test Plan

<!-- Show that the code works as expected by providing testing details. Include commands, steps, or screenshots as necessary. -->

### Prerequisites for Testing

1. Expo SDK 52 environment.
2. Simulator and physical device for testing compatibility.

### Steps to Test

1. Open the app in Expo Go.
2. Navigate to the components that use `RNDateTimePicker`.
3. Ensure the picker functions as expected on both iOS and Android.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅       |
| Android |    ✅       |

## Checklist

<!-- Check completed items -->

- [x] Tested on device and simulator
- [ ] Updated relevant documentation (`README.md`)
- [ ] Updated TypeScript definitions if applicable
- [ ] Added a usage example in the example project (`example/App.js`)
- [ ] Added relevant automated tests
