### PR TITLE
feat: :sparkles: enables theme overlays for material 3 date pickers

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNMaterialDatePicker.kt
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNMaterialDatePicker.kt
@@ -109,12 +109,12 @@ class RNMaterialDatePicker(
   }
 
   private fun obtainMaterialThemeOverlayId(resId: Int): Int {
-    if (reactContext.currentActivity?.theme == null) {
+    val theme = reactContext.currentActivity?.theme ?: run {
       return resId
     }
 
     val typedValue = TypedValue()
-    reactContext.currentActivity!!.theme!!.resolveAttribute(resId, typedValue, true)
+    theme.resolveAttribute(resId, typedValue, true)
     return typedValue.resourceId
   }
 

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNMaterialDatePicker.kt
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNMaterialDatePicker.kt
@@ -2,6 +2,7 @@ package com.reactcommunity.rndatetimepicker
 
 import android.content.DialogInterface
 import android.os.Bundle
+import android.util.TypedValue
 import androidx.fragment.app.FragmentManager
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -13,6 +14,7 @@ import com.google.android.material.datepicker.DateValidatorPointBackward
 import com.google.android.material.datepicker.DateValidatorPointForward
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.datepicker.MaterialPickerOnPositiveButtonClickListener
+import com.google.android.material.R
 import java.util.Calendar
 
 class RNMaterialDatePicker(
@@ -97,12 +99,23 @@ class RNMaterialDatePicker(
 
   private fun setFullscreen() {
     val isFullscreen = args.getBoolean(RNConstants.ARG_FULLSCREEN)
-
     if (isFullscreen) {
-      builder.setTheme(com.google.android.material.R.style.ThemeOverlay_Material3_MaterialCalendar_Fullscreen)
+      val themeId = obtainMaterialThemeOverlayId(R.attr.materialCalendarFullscreenTheme)
+      builder.setTheme(themeId)
     } else {
-      builder.setTheme(com.google.android.material.R.style.ThemeOverlay_Material3_MaterialCalendar)
+      val themeId = obtainMaterialThemeOverlayId(R.attr.materialCalendarTheme)
+      builder.setTheme(themeId)
     }
+  }
+
+  private fun obtainMaterialThemeOverlayId(resId: Int): Int {
+    if (reactContext.currentActivity?.theme == null) {
+      return resId
+    }
+
+    val typedValue = TypedValue()
+    reactContext.currentActivity!!.theme!!.resolveAttribute(resId, typedValue, true)
+    return typedValue.resourceId
   }
 
   private fun addListeners() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
This PR retrieves the resource ID of the materialCalendarTheme specified by the user inside `styles.xml`, which will default to the material 3 theme if not specified. This enables theming the date picker component when using Material 3 instead of user styling being overridden by the default theme.

Issue: https://github.com/react-native-datetimepicker/datetimepicker/issues/960

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅      |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
