### PR TITLE
fix: add ios.componentProvider to codegenConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,11 @@
     "jsSrcsDir": "src/specs",
     "android": {
       "javaPackageName": "com.reactcommunity.rndatetimepicker"
+    },
+    "ios": {
+      "componentProvider": {
+        "RNDateTimePicker": "RNDateTimePickerComponentView"
+      }
     }
   },
   "packageManager": "yarn@4.1.1"


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
- Fix deprecation warning by adding missing `ios.componentProvider` [configuration](https://reactnative.dev/docs/the-new-architecture/using-codegen#configuring-codegen).
- When using `@react-native-community/datetimepicker`, the following deprecation warning appears:

```
[Codegen] [DEPRECATED] @react-native-community/datetimepicker should add the 'ios.componentProvider' property in their codegenConfig
```

<img width="614" alt="image" src="https://github.com/user-attachments/assets/d9e4f047-be0b-44a5-b6da-7b7f66abf78f" />


This maps the JavaScript `RNDateTimePicker` component to the iOS native `RNDateTimePickerComponentView` class for proper codegen support.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
- react-native v0.79.2 & expo sdk 53

### What are the steps to reproduce (after prerequisites)?
- `npx pod-install`

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅   |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
