### PR TITLE
Fix division by zero minute interval

### DIFF
--- a/ios/fabric/RNDateTimePickerComponentView.mm
+++ b/ios/fabric/RNDateTimePickerComponentView.mm
@@ -177,7 +177,6 @@ NSDate* adjustMinimumDate (NSDate* minimumDate, int minuteInterval) {
 
     if (oldPickerProps.minimumDate != newPickerProps.minimumDate) {
         NSDate *minimumDate = convertJSTimeToDate(newPickerProps.minimumDate);
-        NSLog(@"[DateTimePicker] Setting minimumDate, minuteInterval from props: %d", newPickerProps.minuteInterval);
         picker.minimumDate = adjustMinimumDate(minimumDate, newPickerProps.minuteInterval);
     }
 

--- a/ios/fabric/RNDateTimePickerComponentView.mm
+++ b/ios/fabric/RNDateTimePickerComponentView.mm
@@ -22,8 +22,6 @@ NSDate* convertJSTimeToDate (double jsTime) {
 }
 
 NSDate* adjustMinimumDate (NSDate* minimumDate, int minuteInterval) {
-    NSLog(@"[DateTimePicker] adjustMinimumDate called with minuteInterval=%d", minuteInterval);
-    
     // If minuteInterval is not set or invalid, return the date unchanged
     if (minuteInterval <= 0) {
         NSLog(@"[DateTimePicker] minuteInterval is %d, returning minimumDate without adjustment", minuteInterval);
@@ -31,8 +29,6 @@ NSDate* adjustMinimumDate (NSDate* minimumDate, int minuteInterval) {
     }
     
     NSInteger minute = [[NSCalendar currentCalendar] component:NSCalendarUnitMinute fromDate:minimumDate];
-    NSLog(@"[DateTimePicker] Adjusting minimumDate minute=%ld to align with interval=%d", (long)minute, minuteInterval);
-    
     NSInteger remainder = minute % minuteInterval;
     NSInteger adjustment = (remainder == 0) ? 0 : (minuteInterval - remainder);
     return [[NSCalendar currentCalendar] dateByAddingUnit:NSCalendarUnitMinute

--- a/ios/fabric/RNDateTimePickerComponentView.mm
+++ b/ios/fabric/RNDateTimePickerComponentView.mm
@@ -24,7 +24,6 @@ NSDate* convertJSTimeToDate (double jsTime) {
 NSDate* adjustMinimumDate (NSDate* minimumDate, int minuteInterval) {
     // If minuteInterval is not set or invalid, return the date unchanged
     if (minuteInterval <= 0) {
-        NSLog(@"[DateTimePicker] minuteInterval is %d, returning minimumDate without adjustment", minuteInterval);
         return minimumDate;
     }
     

--- a/ios/fabric/RNDateTimePickerComponentView.mm
+++ b/ios/fabric/RNDateTimePickerComponentView.mm
@@ -22,7 +22,17 @@ NSDate* convertJSTimeToDate (double jsTime) {
 }
 
 NSDate* adjustMinimumDate (NSDate* minimumDate, int minuteInterval) {
+    NSLog(@"[DateTimePicker] adjustMinimumDate called with minuteInterval=%d", minuteInterval);
+    
+    // If minuteInterval is not set or invalid, return the date unchanged
+    if (minuteInterval <= 0) {
+        NSLog(@"[DateTimePicker] minuteInterval is %d, returning minimumDate without adjustment", minuteInterval);
+        return minimumDate;
+    }
+    
     NSInteger minute = [[NSCalendar currentCalendar] component:NSCalendarUnitMinute fromDate:minimumDate];
+    NSLog(@"[DateTimePicker] Adjusting minimumDate minute=%ld to align with interval=%d", (long)minute, minuteInterval);
+    
     NSInteger remainder = minute % minuteInterval;
     NSInteger adjustment = (remainder == 0) ? 0 : (minuteInterval - remainder);
     return [[NSCalendar currentCalendar] dateByAddingUnit:NSCalendarUnitMinute
@@ -171,6 +181,7 @@ NSDate* adjustMinimumDate (NSDate* minimumDate, int minuteInterval) {
 
     if (oldPickerProps.minimumDate != newPickerProps.minimumDate) {
         NSDate *minimumDate = convertJSTimeToDate(newPickerProps.minimumDate);
+        NSLog(@"[DateTimePicker] Setting minimumDate, minuteInterval from props: %d", newPickerProps.minuteInterval);
         picker.minimumDate = adjustMinimumDate(minimumDate, newPickerProps.minuteInterval);
     }
 


### PR DESCRIPTION
# Summary

The application crashes when `minuteInterval` is not provided or is 0. The issue was introduced in the previous PR which modified the minimum date check https://github.com/react-native-datetimepicker/datetimepicker/pull/992

Fixes https://github.com/react-native-datetimepicker/datetimepicker/issues/996

## Test Plan

- Add the component
- Dont provide minimumDate prop
- The app crashes

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
