### PR TITLE
Fix/#67

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ React Native date & time picker component for iOS, Android and Windows (please n
     - [`initialInputMode` (`optional`, `Android only`)](#initialinputmode-optional-android-only)
     - [`title` (`optional`, `Android only`)](#title-optional-android-only)
     - [`fullscreen` (`optional`, `Android only`)](#fullscreen-optional-android-only)
+    - [`showYearPickerFirst` (`optional`, `Android only`)](#showyearpickerfirst-optional-android-only)
     - [`onChange` (`optional`)](#onchange-optional)
     - [`value` (`required`)](#value-required)
     - [`maximumDate` (`optional`)](#maximumdate-optional)
@@ -532,6 +533,14 @@ List of possible values:
 
 ```js
 <RNDateTimePicker fullscreen={true} />
+```
+
+#### `showYearPickerFirst` (`optional`, `Android only`)
+
+If true, the date picker will open with the year selector first.
+
+```js
+<RNDateTimePicker showYearPickerFirst={true} />
 ```
 
 #### `positiveButton` (`optional`, `Android only`)

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java
@@ -1,13 +1,16 @@
 package com.reactcommunity.rndatetimepicker;
 
 import android.app.AlertDialog;
+import android.app.DatePickerDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.util.TypedValue;
+import android.view.View;
 import android.widget.Button;
+import android.widget.DatePicker;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.ColorRes;
@@ -91,6 +94,30 @@ public class Common {
       setTextColor(neutralButton, NEUTRAL, args, needsColorOverride, textColorPrimary);
     };
 	}
+
+  @NonNull
+  public static DialogInterface.OnShowListener openYearDialog(final AlertDialog dialog, final boolean canOpenYearDialog, final boolean showYearPickerFirst) {
+    return dialogInterface -> {
+      if (canOpenYearDialog && showYearPickerFirst && dialog instanceof DatePickerDialog datePickerDialog) {
+        DatePicker datePicker = datePickerDialog.getDatePicker();
+
+        int yearId = Resources.getSystem().getIdentifier("date_picker_header_year", "id", "android");
+        View yearView = datePicker.findViewById(yearId);
+        if (yearView != null) {
+          yearView.performClick();
+        }
+      }
+    };
+  }
+
+  @NonNull
+  public static DialogInterface.OnShowListener combine(@NonNull DialogInterface.OnShowListener... listeners) {
+    return dialogInterface -> {
+      for (DialogInterface.OnShowListener l : listeners) {
+        if (l != null) l.onShow(dialogInterface);
+      }
+    };
+  }
 
   private static void setTextColor(Button button, String buttonKey, final Bundle args, final boolean needsColorOverride, int textColorPrimary) {
     if (button == null) return;
@@ -244,6 +271,9 @@ public class Common {
       // FIRST_DAY_OF_WEEK is 0-indexed, since it uses the same constants DAY_OF_WEEK used in the Windows implementation
       // Android DatePicker uses 1-indexed values, SUNDAY being 1 and SATURDAY being 7, so the +1 is necessary in this case
       args.putInt(RNConstants.FIRST_DAY_OF_WEEK, options.getInt(RNConstants.FIRST_DAY_OF_WEEK)+1);
+    }
+    if (options.hasKey(RNConstants.ARG_SHOW_YEAR_PICKER_FIRST) && !options.isNull(RNConstants.ARG_SHOW_YEAR_PICKER_FIRST)) {
+      args.putBoolean(RNConstants.ARG_SHOW_YEAR_PICKER_FIRST, options.getBoolean(RNConstants.ARG_SHOW_YEAR_PICKER_FIRST));
     }
     return args;
   }

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNConstants.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNConstants.java
@@ -22,6 +22,7 @@ public final class RNConstants {
   public static final String ACTION_DISMISSED = "dismissedAction";
   public static final String ACTION_NEUTRAL_BUTTON = "neutralButtonAction";
   public static final String FIRST_DAY_OF_WEEK = "firstDayOfWeek";
+  public static final String ARG_SHOW_YEAR_PICKER_FIRST = "showYearPickerFirst";
 
   /**
    * Minimum date supported by {@link TimePickerDialog}, 01 Jan 1900

--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java
@@ -7,7 +7,9 @@
 
 package com.reactcommunity.rndatetimepicker;
 
+import static com.reactcommunity.rndatetimepicker.Common.combine;
 import static com.reactcommunity.rndatetimepicker.Common.getDisplayDate;
+import static com.reactcommunity.rndatetimepicker.Common.openYearDialog;
 import static com.reactcommunity.rndatetimepicker.Common.setButtonTextColor;
 import static com.reactcommunity.rndatetimepicker.Common.setButtonTitles;
 
@@ -101,7 +103,14 @@ public class RNDatePickerDialogFragment extends DialogFragment {
       if (activityContext != null) {
         RNDatePickerDisplay display = getDisplayDate(args);
         boolean needsColorOverride = display == RNDatePickerDisplay.SPINNER;
-        dialog.setOnShowListener(setButtonTextColor(activityContext, dialog, args, needsColorOverride));
+        boolean canOpenYearDialog = display == RNDatePickerDisplay.DEFAULT;
+        boolean showYearPickerFirst = args.getBoolean(RNConstants.ARG_SHOW_YEAR_PICKER_FIRST);
+        dialog.setOnShowListener(
+          combine(
+            openYearDialog(dialog, canOpenYearDialog, showYearPickerFirst),
+            setButtonTextColor(activityContext, dialog, args, needsColorOverride)
+          )
+        );
       }
     }
 

--- a/example/App.js
+++ b/example/App.js
@@ -106,6 +106,7 @@ export const App = () => {
   const [neutralButtonLabel, setNeutralButtonLabel] = useState(undefined);
   const [disabled, setDisabled] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [showYearPickerFirst, setShowYearPickerFirst] = useState(false);
   const [minimumDate, setMinimumDate] = useState();
   const [maximumDate, setMaximumDate] = useState();
   const [design, setDesign] = useState(DESIGNS[0]);
@@ -388,6 +389,14 @@ export const App = () => {
           </View>
           <View style={styles.header}>
             <ThemedText style={styles.textLabel}>
+              showYearPickerFirst (android only)
+            </ThemedText>
+            <View style={{flex: 1, alignItems: 'flex-start'}}>
+              <Switch value={showYearPickerFirst} onValueChange={setShowYearPickerFirst} />
+            </View>
+          </View>
+          <View style={styles.header}>
+            <ThemedText style={styles.textLabel}>
               neutralButtonLabel (android only)
             </ThemedText>
             <ThemedTextInput
@@ -501,6 +510,7 @@ export const App = () => {
                 initialInputMode={isMaterialDesign ? inputMode : undefined}
                 design={design}
                 fullscreen={isMaterialDesign ? isFullscreen : undefined}
+                showYearPickerFirst={showYearPickerFirst}
               />
             )}
           </View>

--- a/src/DateTimePickerAndroid.android.js
+++ b/src/DateTimePickerAndroid.android.js
@@ -51,6 +51,7 @@ function open(props: AndroidNativeProps) {
     initialInputMode,
     design,
     fullscreen,
+    showYearPickerFirst,
   } = props;
   validateAndroidProps(props);
   invariant(originalValue, 'A date or time must be specified as `value` prop.');
@@ -97,6 +98,7 @@ function open(props: AndroidNativeProps) {
         title,
         initialInputMode,
         fullscreen,
+        showYearPickerFirst,
       });
 
       switch (action) {

--- a/src/androidUtils.js
+++ b/src/androidUtils.js
@@ -38,6 +38,7 @@ type OpenParams = {
   title: AndroidNativeProps['title'],
   design: AndroidNativeProps['design'],
   fullscreen: AndroidNativeProps['fullscreen'],
+  showYearPickerFirst: AndroidNativeProps['showYearPickerFirst'],
 };
 
 export type PresentPickerCallback =
@@ -88,6 +89,7 @@ function getOpenPicker(
         title,
         initialInputMode,
         fullscreen,
+        showYearPickerFirst,
       }: OpenParams) =>
         // $FlowFixMe - `AbstractComponent` [1] is not an instance type.
         pickers[ANDROID_MODE.date].open({
@@ -103,6 +105,7 @@ function getOpenPicker(
           title,
           initialInputMode,
           fullscreen,
+          showYearPickerFirst,
         });
   }
 }

--- a/src/datetimepicker.android.js
+++ b/src/datetimepicker.android.js
@@ -37,6 +37,7 @@ export default function RNDateTimePickerAndroid(
     initialInputMode,
     design,
     fullscreen,
+    showYearPickerFirst,
   } = props;
   const valueTimestamp = value.getTime();
 
@@ -72,6 +73,7 @@ export default function RNDateTimePickerAndroid(
         initialInputMode,
         design,
         fullscreen,
+        showYearPickerFirst,
       };
       DateTimePickerAndroid.open(params);
     },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -203,6 +203,10 @@ export type AndroidNativeProps = Readonly<
        * Use Material 3 pickers or the default ones
        */
       design?: Design;
+      /**
+       * Show the year picker first when opening the calendar dialog.
+       */
+      showYearPickerFirst?: boolean;
     }
 >;
 

--- a/src/specs/NativeModuleDatePicker.js
+++ b/src/specs/NativeModuleDatePicker.js
@@ -11,6 +11,7 @@ export type DatePickerOpenParams = $ReadOnly<{
   testID?: string,
   timeZoneName?: number,
   timeZoneOffsetInMinutes?: number,
+  showYearPickerFirst?: boolean,
 }>;
 
 type DateSetAction = 'dateSetAction' | 'dismissedAction';

--- a/src/specs/NativeModuleMaterialDatePicker.js
+++ b/src/specs/NativeModuleMaterialDatePicker.js
@@ -14,6 +14,7 @@ export type DatePickerOpenParams = $ReadOnly<{
   timeZoneName?: number,
   timeZoneOffsetInMinutes?: number,
   firstDayOfWeek?: number,
+  showYearPickerFirst?: boolean,
 }>;
 
 type DateSetAction = 'dateSetAction' | 'dismissedAction';

--- a/src/types.js
+++ b/src/types.js
@@ -219,6 +219,13 @@ export type AndroidNativeProps = $ReadOnly<{|
   design?: 'default' | 'material',
 
   /**
+   * If true, the date picker will open with the year selector first.
+   *
+   * Only supported for default pickers.
+   */
+  showYearPickerFirst?: boolean,
+
+  /**
    * The interval at which minutes can be selected.
    *
    * Not supported in Material 3 pickers


### PR DESCRIPTION
# Summary

This pull request addresses issue #67 by adding a feature that allows the year picker to be shown first.

Implementation details:
- For DatePickerDialog: Used an OnShowListener so that when the dialog is displayed, the year view button is retrieved via the date_picker_header_year ID and programmatically clicked to show the year selector.
- For MaterialDatePicker: Retrieved the view responsible for displaying the year within the picker’s view group and programmatically triggered it to switch to the year selection view.

## Test Plan

Tested using an Android emulator.

- Pixel 6 (Android 12) DatePickerDialog

https://github.com/user-attachments/assets/3f7dc078-9798-4ea5-9c41-0ae67defae82

- Pixel 6 (Android 12) MaterialDatePicker

https://github.com/user-attachments/assets/e71162b5-83ac-48cd-9a01-5d993b3389bd

- Pixel 7 (Android 14) DatePickerDialog

https://github.com/user-attachments/assets/510a7b30-4fc8-401c-ab71-d27ef8de60c9

- Pixel 7 (Android 14) MaterialDatePicker

https://github.com/user-attachments/assets/a0fd76e5-b606-405c-a0b5-c997a0017047

- Nexus 5X (Android 7) DatePickerDialog

https://github.com/user-attachments/assets/c1c63264-d1f1-4927-b507-ec1db23b3676

- Nexus 5X (Android 7) MaterialDatePicker

https://github.com/user-attachments/assets/236f5c58-38fe-4142-b168-47484482e5a1

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ❌     |
| Android |    ✅      |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
