### PR TITLE
fix(ios): fix min/max date crash

### DIFF
--- a/ios/fabric/RNDateTimePickerComponentView.mm
+++ b/ios/fabric/RNDateTimePickerComponentView.mm
@@ -187,8 +187,7 @@ NSDate* adjustMinimumDate (NSDate* minimumDate, int minuteInterval) {
         if (newPickerProps.maximumDate == 0.0) {
             picker.maximumDate = nil;
         } else {
-            NSDate *maximumDate = convertJSTimeToDate(newPickerProps.maximumDate);
-            picker.maximumDate = adjustMaximumDate(maximumDate, newPickerProps.minuteInterval);
+            picker.maximumDate = convertJSTimeToDate(newPickerProps.maximumDate);
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

This PR fixes a bug that would occur on iOS (new arch) in the following situation:
- multiple date picker instances across the app
- different type of date pickers
- some with min/max date, some that don't have those
- upon successive opening of those pickers, we could encounter native crashes related to invalid bounds, for example: 

```
NSInternalInconsistencyException: Invalid state. Unable to find a lower bounds in range.
```

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅      |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
