### PR TITLE
fix(ios): avoid min>max date picker crash

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -471,6 +471,24 @@ export const App = () => {
               title="toggleMinMaxDate"
             />
           </View>
+          {/* This button allows for testing the error box that should show when the minimumDate prop is greater than the maximumDate prop */}
+          <View style={styles.button}>
+            <Button
+              testID="setInvertedMinMax"
+              onPress={() => {
+                if (minimumDate && maximumDate && minimumDate > maximumDate) {
+                  setMinimumDate(undefined);
+                  setMaximumDate(undefined);
+                  setShow(false);
+                } else {  
+                  setMinimumDate(new Date('2025-09-05'));
+                  setMaximumDate(new Date('2025-09-01'));
+                  setShow(true);
+                }
+              }}
+              title={minimumDate && maximumDate && minimumDate > maximumDate ? "undo min > max" : "set min > max (errors)"}
+            />
+          </View>
           <View style={{flexDirection: 'row', alignItems: 'center'}}>
             {/* This label ensures there is no regression in this former bug: https://github.com/react-native-datetimepicker/datetimepicker/issues/409 */}
             <Text style={{flexShrink: 1}}>

--- a/ios/fabric/RNDateTimePickerComponentView.mm
+++ b/ios/fabric/RNDateTimePickerComponentView.mm
@@ -174,13 +174,26 @@ NSDate* adjustMinimumDate (NSDate* minimumDate, int minuteInterval) {
         needsToUpdateMeasurements = true;
     }
 
-    if (oldPickerProps.minimumDate != newPickerProps.minimumDate) {
-        NSDate *minimumDate = convertJSTimeToDate(newPickerProps.minimumDate);
-        picker.minimumDate = adjustMinimumDate(minimumDate, newPickerProps.minuteInterval);
-    }
-
-    if (oldPickerProps.maximumDate != newPickerProps.maximumDate) {
-        picker.maximumDate = convertJSTimeToDate(newPickerProps.maximumDate);
+    if (oldPickerProps.minimumDate != newPickerProps.minimumDate || 
+        oldPickerProps.maximumDate != newPickerProps.maximumDate) {
+        
+        NSDate *newMinDate = convertJSTimeToDate(newPickerProps.minimumDate);
+        NSDate *newMaxDate = convertJSTimeToDate(newPickerProps.maximumDate);
+        
+        if (newMinDate) {
+            newMinDate = adjustMinimumDate(newMinDate, newPickerProps.minuteInterval);
+        }
+        
+        // avoid crash when min > max by ensuring a clean initial state
+        picker.minimumDate = nil;
+        picker.maximumDate = nil;
+        
+        // set the dates in all cases (whether unset/nil, some set, or both set)
+        // UNLESS min > max, then we leave them as nil and rely on our LogBox in JS
+        if (!newMinDate || !newMaxDate || [newMinDate compare:newMaxDate] != NSOrderedDescending) {
+            picker.minimumDate = newMinDate;
+            picker.maximumDate = newMaxDate;
+        }
     }
 
     if (oldPickerProps.locale != newPickerProps.locale) {

--- a/ios/fabric/RNDateTimePickerComponentView.mm
+++ b/ios/fabric/RNDateTimePickerComponentView.mm
@@ -174,11 +174,12 @@ NSDate* adjustMinimumDate (NSDate* minimumDate, int minuteInterval) {
         needsToUpdateMeasurements = true;
     }
 
-    if (oldPickerProps.minimumDate != newPickerProps.minimumDate || 
-        oldPickerProps.maximumDate != newPickerProps.maximumDate) {
-        
-        NSDate *newMinDate = convertJSTimeToDate(newPickerProps.minimumDate);
-        NSDate *newMaxDate = convertJSTimeToDate(newPickerProps.maximumDate);
+    Boolean minDateChanged = oldPickerProps.minimumDate != newPickerProps.minimumDate;
+    Boolean maxDateChanged = oldPickerProps.maximumDate != newPickerProps.maximumDate;
+    
+    if (minDateChanged || maxDateChanged) {
+        NSDate *newMinDate = newPickerProps.minimumDate ? convertJSTimeToDate(newPickerProps.minimumDate) : nil;
+        NSDate *newMaxDate = newPickerProps.maximumDate ? convertJSTimeToDate(newPickerProps.maximumDate) : nil;
         
         if (newMinDate) {
             newMinDate = adjustMinimumDate(newMinDate, newPickerProps.minuteInterval);

--- a/src/datetimepicker.ios.js
+++ b/src/datetimepicker.ios.js
@@ -61,7 +61,7 @@ export default function Picker({
   disabled = false,
   ...other
 }: IOSNativeProps): React.Node {
-  sharedPropsValidation({value, timeZoneOffsetInMinutes, timeZoneName});
+  sharedPropsValidation({value, timeZoneOffsetInMinutes, timeZoneName, minimumDate, maximumDate});
 
   const display = getDisplaySafe(providedDisplay);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -57,7 +57,7 @@ export function sharedPropsValidation({
   if (minimumDate && maximumDate) {
     invariant(
       minimumDate <= maximumDate,
-      `DateTimePicker: minimumDate (${minimumDate.toISOString()}) is after maximumDate (${maximumDate.toISOString()}). Please ensure minimumDate <= maximumDate.`,
+      `DateTimePicker: minimumDate (${minimumDate.toISOString()}) is after maximumDate (${maximumDate.toISOString()}). Please ensure minimumDate < maximumDate.`,
     );
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,10 +35,14 @@ export function sharedPropsValidation({
   value,
   timeZoneName,
   timeZoneOffsetInMinutes,
+  minimumDate,
+  maximumDate,
 }: {
   value: Date,
   timeZoneName?: ?string,
   timeZoneOffsetInMinutes?: ?number,
+  minimumDate?: ?Date,
+  maximumDate?: ?Date,
 }) {
   invariant(value, 'A date or time must be specified as `value` prop');
   invariant(
@@ -49,6 +53,14 @@ export function sharedPropsValidation({
     timeZoneName == null || timeZoneOffsetInMinutes == null,
     '`timeZoneName` and `timeZoneOffsetInMinutes` cannot be specified at the same time',
   );
+
+  if (minimumDate && maximumDate) {
+    invariant(
+      minimumDate <= maximumDate,
+      `DateTimePicker: minimumDate (${minimumDate.toISOString()}) is after maximumDate (${maximumDate.toISOString()}). Please ensure minimumDate <= maximumDate.`,
+    );
+  }
+
   if (timeZoneOffsetInMinutes !== undefined) {
     console.warn(
       '`timeZoneOffsetInMinutes` is deprecated and will be removed in a future release. Use `timeZoneName` instead.',

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -73,7 +73,7 @@ describe('utils', () => {
 
         expect(() => {
           sharedPropsValidation({value, minimumDate, maximumDate});
-        }).toThrow('DateTimePicker: minimumDate (2023-12-31T00:00:00.000Z) is after maximumDate (2023-01-01T00:00:00.000Z). Please ensure minimumDate <= maximumDate.');
+        }).toThrow('DateTimePicker: minimumDate (2023-12-31T00:00:00.000Z) is after maximumDate (2023-01-01T00:00:00.000Z). Please ensure minimumDate < maximumDate.');
       });
     });
   });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,4 +1,4 @@
-import {toMilliseconds} from '../src/utils.js';
+import {toMilliseconds, sharedPropsValidation} from '../src/utils.js';
 
 describe('utils', () => {
   describe('toMilliseconds', () => {
@@ -15,6 +15,66 @@ describe('utils', () => {
       toMilliseconds(options, 'minimumDate', 'maximumDate');
       expect(options).toHaveProperty('minimumDate', -631152000000);
       expect(options).toHaveProperty('maximumDate', 2556057600000);
+    });
+  });
+
+  describe('sharedPropsValidation', () => {
+    describe('minimumDate and maximumDate validation', () => {
+      it('should not throw when dates are in correct order', () => {
+        const value = new Date('2023-06-15');
+        const minimumDate = new Date('2023-01-01');
+        const maximumDate = new Date('2023-12-31');
+
+        expect(() => {
+          sharedPropsValidation({value, minimumDate, maximumDate});
+        }).not.toThrow();
+      });
+
+      it('should not throw when dates are equal', () => {
+        const value = new Date('2023-06-15');
+        const minimumDate = new Date('2023-06-15');
+        const maximumDate = new Date('2023-06-15');
+
+        expect(() => {
+          sharedPropsValidation({value, minimumDate, maximumDate});
+        }).not.toThrow();
+      });
+
+      it('should not throw when only minimumDate is provided', () => {
+        const value = new Date('2023-06-15');
+        const minimumDate = new Date('2023-01-01');
+
+        expect(() => {
+          sharedPropsValidation({value, minimumDate});
+        }).not.toThrow();
+      });
+
+      it('should not throw when only maximumDate is provided', () => {
+        const value = new Date('2023-06-15');
+        const maximumDate = new Date('2023-12-31');
+
+        expect(() => {
+          sharedPropsValidation({value, maximumDate});
+        }).not.toThrow();
+      });
+
+      it('should not throw when neither minimumDate nor maximumDate is provided', () => {
+        const value = new Date('2023-06-15');
+
+        expect(() => {
+          sharedPropsValidation({value});
+        }).not.toThrow();
+      });
+
+      it('should throw when minimumDate is after maximumDate', () => {
+        const value = new Date('2023-06-15');
+        const minimumDate = new Date('2023-12-31');
+        const maximumDate = new Date('2023-01-01');
+
+        expect(() => {
+          sharedPropsValidation({value, minimumDate, maximumDate});
+        }).toThrow('DateTimePicker: minimumDate (2023-12-31T00:00:00.000Z) is after maximumDate (2023-01-01T00:00:00.000Z). Please ensure minimumDate <= maximumDate.');
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This change fixes a crash on iOS when the underlying UIDatePicker receives minimumDate > maximumDate by:

- adding validation in JS to assert that when both are set, min must be less than max
- updating the native fabric prop update logic to:
  - explicitly handles unsetting prior values on the underlying picker during any change before setting new ones
  - specifically handles the unset case which was handled implicitly before

This is the error that shows after this change in dev mode when this happens (before it just crashes):

<img width="320" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-09 at 21 58 50" src="https://github.com/user-attachments/assets/dbf278d7-345f-4950-9eba-31f88e04f7cd" />

<details>
<summary>Original Crash</summary>

```
*** Terminating app due to uncaught exception 'NSGenericException', reason: 'Start date cannot be later in time than end date!'
*** First throw call stack:
(
	0   CoreFoundation                      0x00000001804c9690 __exceptionPreprocess + 172
	1   libobjc.A.dylib                     0x00000001800937cc objc_exception_throw + 72
	2   Foundation                          0x0000000180f55184 -[_NSConcreteDateInterval initWithStartDate:endDate:] + 396
	3   UIKitCore                           0x00000001850dfee0 -[_UIDatePickerCalendarView _reloadCalendarView] + 352
	4   UIKitCore                           0x00000001850dffa4 -[_UIDatePickerCalendarView _reload] + 48
	5   UIKitCore                           0x0000000185bfd72c -[UIDatePicker _installPickerView:updatingSize:] + 152
	6   UIKitCore                           0x0000000185bfd650 -[UIDatePicker _updatePickerViewIfNecessary] + 120
	7   ReproducerApp.debug.dylib           0x0000000107242670 -[RNDateTimePickerComponentView updatePropsForPicker:props:oldProps:
```

</details>

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

Reproducer used in screenshots below: https://github.com/sterlingwes/date-picker-min-max-repro

The reproducer tests the following scenarios:

<img width="325" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-09 at 19 21 13" src="https://github.com/user-attachments/assets/12fb3f56-29c6-4d70-a595-11a673f7266a" />

<details>
<summary>Behaviour before fixes</summary>

| first | second                                                                                                                                                                                       | third                                                                                                                                                                                        | fourth                                                                                                                                                                                       | fifth                                                                                                                                                                                        |
| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 💥    | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-09 at 19 21 16" src="https://github.com/user-attachments/assets/12f671e9-595b-413d-ab7d-afbff63e2998" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-09 at 19 21 34" src="https://github.com/user-attachments/assets/7ccb7793-b256-4363-8516-97027eb476d4" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-09 at 19 21 37" src="https://github.com/user-attachments/assets/9af606ad-9919-4939-b95e-8a6899819f81" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-09 at 19 21 41" src="https://github.com/user-attachments/assets/9faff45d-7baa-4372-9919-5d000d604c07" /> |

</details>

<details>
<summary>Behaviour after fixes</summary>

| first                                                                                                                                                                                        | second                                                                                                                                                                                   | third                                                                                                                                                                                    | fourth                                                                                                                                                                                   | fifth                                                                                                                                                                                    |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-09 at 18 54 41" src="https://github.com/user-attachments/assets/e0a8d7ec-0a41-4847-b2b7-005ff8f4fbf3" /> | <img width="1206" height="2622" alt="simulator_screenshot_0C99FF94-596E-4676-8D7F-E53C5D0B2FEF" src="https://github.com/user-attachments/assets/64f7bcb3-f826-40ee-8668-1a2a9fe11937" /> | <img width="1206" height="2622" alt="simulator_screenshot_D9476BAC-578E-43A8-9952-8F64F0093BB2" src="https://github.com/user-attachments/assets/9517404f-c1f1-4c25-9112-be60bbd8e530" /> | <img width="1206" height="2622" alt="simulator_screenshot_5A56C3D5-C3E9-445C-9777-19868DEE9190" src="https://github.com/user-attachments/assets/5d1cda4a-9cff-4301-a96c-20da6189c0d0" /> | <img width="1206" height="2622" alt="simulator_screenshot_AE3AAD97-42B3-4957-8BEF-23E66B455515" src="https://github.com/user-attachments/assets/7100b496-2ce9-42cd-b793-10840a5b4746" /> |

</details>

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

You can either:

* Use the example app here, which has a simple reproduction case for toggling-on min > max constraint
* [Use the reproducer](https://github.com/sterlingwes/date-picker-min-max-repro)

### What are the steps to reproduce (after prerequisites)?

To reproduce the crash in the example app, tap the new button "set min > max (error)" then tap the picker date and it should crash. If you test on this branch that includes the changes in `ios/fabric/RNDateTimePickerComponentView.mm` and in `src/utils.js`, you should instead see the logbox error shown first above.

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

The native crash was only evident on iOS, but the JS validation approach taken here ensures the expectation is aligned across both.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
- [x] I have added automated tests, either in JS or e2e tests, as applicable

* i did not see a reason to add docs for this as the error more clearly documents the expectation now
* i only added js unit specs as the e2e spec tests similar things (js logbox behaviour)