### PR TITLE
fix(ios): internal picker state persisting with recycling

### DIFF
--- a/ios/fabric/RNDateTimePickerComponentView.mm
+++ b/ios/fabric/RNDateTimePickerComponentView.mm
@@ -115,10 +115,9 @@ NSDate* adjustMinimumDate (NSDate* minimumDate, int minuteInterval) {
     return concreteComponentDescriptorProvider<RNDateTimePickerComponentDescriptor>();
 }
 
-- (void)prepareForRecycle
++ (BOOL)shouldBeRecycled
 {
-    [super prepareForRecycle];
-    _state.reset();
+  return NO;
 }
 
 -(void)updateTextColorForPicker:(UIDatePicker *)picker color:(UIColor *)color


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Follow-up to the min/max constraint fix in https://github.com/react-native-datetimepicker/datetimepicker/pull/1009. There was a pre-existing issue when the component gets unmounted: the native component gets recycled for future reuse but keeps its picker instance properties along with their state.

This likely would have also fixed the earlier issue but I think those changes are worth keeping as they make it clearer how the UIDatePicker constraints operate.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

**Video showing the crash case:**

https://github.com/user-attachments/assets/da84a496-3278-47e4-9b85-f109862a2bb5

Two breakpoints here:
* one in the recycle lifecycle method to show that the picker retains constraints
* one right before we apply props for the next picker to show that the constraints are stale before the crash

**Video showing the fix:**

https://github.com/user-attachments/assets/af535623-ce43-4287-ab88-b2657f08ec06

Breakpoints show that the min/max date constraints are cleared

### What's required for testing (prerequisites)?

I copied over [this component from the reproduction app](https://github.com/Junveloper/react-native-datetimepicker-bug/blob/main/app/date-modal.tsx) ([provided by @Junveloper in the prior PR](https://github.com/react-native-datetimepicker/datetimepicker/pull/1009#issuecomment-3568011729)). You can reference this branch for the changes required: https://github.com/sterlingwes/datetimepicker/pull/1

### What are the steps to reproduce (after prerequisites)?

* open the modal
  * pick two dates in the next month
  * submit / close modal
* open modal again
  * tap to pick first date and it should crash

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
