### PR TITLE
fix(android): material date picker off by one day

### DIFF
--- a/android/src/main/java/com/reactcommunity/rndatetimepicker/RNMaterialDatePicker.kt
+++ b/android/src/main/java/com/reactcommunity/rndatetimepicker/RNMaterialDatePicker.kt
@@ -179,8 +179,14 @@ class RNMaterialDatePicker(
         )
       )
 
-      newCalendar.timeInMillis = selection
+      // Material DatePicker returns timestamp in UTC at midnight for the selected date.
+      // Extract year, month, day from UTC, then set them in the target timezone
+      val utcCalendar = Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"))
+      utcCalendar.timeInMillis = selection
 
+      newCalendar[Calendar.YEAR] = utcCalendar[Calendar.YEAR]
+      newCalendar[Calendar.MONTH] = utcCalendar[Calendar.MONTH]
+      newCalendar[Calendar.DAY_OF_MONTH] = utcCalendar[Calendar.DAY_OF_MONTH]
       newCalendar[Calendar.HOUR_OF_DAY] = initialDate.hour()
       newCalendar[Calendar.MINUTE] = initialDate.minute()
       newCalendar[Calendar.SECOND] = 0


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
The Material DatePicker returns a midnight UTC timestamp when picking a date, so when the timezone was behind UTC (e.g. PST), the final date would be set to the previous day to the one picked.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Tested in Android Emulator set to PST timezone

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

<!-- remove ✅ / ❌ to show what platforms this covers -->

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    n/a     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a ~device and a~ simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
