### PR TITLE
fix(android): support numbersInnerTextColor in config plugin

### DIFF
--- a/docs/android-styling.md
+++ b/docs/android-styling.md
@@ -69,5 +69,6 @@ The following illustrations show the different styles that can be applied to the
 | background             | android:background             |
 | headerBackground       | android:headerBackground       |
 | numbersBackgroundColor | android:numbersBackgroundColor |
+| numbersInnerTextColor  | android:numbersInnerTextColor  |
 | numbersSelectorColor   | android:numbersSelectorColor   |
 | numbersTextColor       | android:numbersTextColor       |

--- a/plugin/src/__tests__/withDateTimePickerStyles.test.js
+++ b/plugin/src/__tests__/withDateTimePickerStyles.test.js
@@ -1,0 +1,81 @@
+import {promises as fs} from 'fs';
+import path from 'path';
+import {compileModsAsync} from '@expo/config-plugins';
+
+import withDateTimePickerStyles from '../withDateTimePickerStyles';
+
+const temporaryProjectRoots = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryProjectRoots
+      .splice(0)
+      .map((projectRoot) => fs.rm(projectRoot, {recursive: true, force: true})),
+  );
+});
+
+const runAndroidPrebuild = async (timePicker) => {
+  const projectRoot = await fs.mkdtemp(
+    path.join(__dirname, 'android-prebuild-'),
+  );
+  temporaryProjectRoots.push(projectRoot);
+
+  const valuesPath = path.join(projectRoot, 'android/app/src/main/res/values');
+  const valuesNightPath = path.join(
+    projectRoot,
+    'android/app/src/main/res/values-night',
+  );
+
+  await Promise.all([
+    fs.mkdir(valuesPath, {recursive: true}),
+    fs.mkdir(valuesNightPath, {recursive: true}),
+  ]);
+  await Promise.all([
+    fs.writeFile(
+      path.join(valuesPath, 'styles.xml'),
+      '<resources><style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar" /></resources>',
+    ),
+    fs.writeFile(path.join(valuesPath, 'colors.xml'), '<resources />'),
+    fs.writeFile(path.join(valuesNightPath, 'colors.xml'), '<resources />'),
+  ]);
+
+  const config = withDateTimePickerStyles(
+    {name: 'datetimepicker-plugin-test', slug: 'datetimepicker-plugin-test'},
+    {android: {timePicker}},
+  );
+
+  await compileModsAsync(config, {projectRoot, platforms: ['android']});
+
+  return {
+    colors: await fs.readFile(path.join(valuesPath, 'colors.xml'), 'utf8'),
+    colorsNight: await fs.readFile(
+      path.join(valuesNightPath, 'colors.xml'),
+      'utf8',
+    ),
+    styles: await fs.readFile(path.join(valuesPath, 'styles.xml'), 'utf8'),
+  };
+};
+
+describe('withDateTimePickerStyles Android prebuild', () => {
+  it('writes the inner time picker text colors and style attribute', async () => {
+    const {colors, colorsNight, styles} = await runAndroidPrebuild({
+      numbersInnerTextColor: {light: '#123456', dark: '#abcdef'},
+    });
+
+    expect(styles).toContain(
+      '<item name="android:numbersInnerTextColor">@color/timePicker_numbersInnerTextColor</item>',
+    );
+    expect(colors).toContain(
+      '<color name="timePicker_numbersInnerTextColor">#123456</color>',
+    );
+    expect(colorsNight).toContain(
+      '<color name="timePicker_numbersInnerTextColor">#abcdef</color>',
+    );
+  });
+
+  it('still rejects an unknown time picker attribute', async () => {
+    await expect(
+      runAndroidPrebuild({unknownTextColor: {light: '#123456'}}),
+    ).rejects.toThrow('Invalid attribute name: unknownTextColor');
+  });
+});

--- a/plugin/src/withDateTimePickerStyles.ts
+++ b/plugin/src/withDateTimePickerStyles.ts
@@ -59,6 +59,9 @@ const TIME_PICKER_ALLOWED_ATTRIBUTES = {
   numbersBackgroundColor: {
     attrName: 'android:numbersBackgroundColor',
   },
+  numbersInnerTextColor: {
+    attrName: 'android:numbersInnerTextColor',
+  },
   numbersSelectorColor: {
     attrName: 'android:numbersSelectorColor',
   },


### PR DESCRIPTION
# Summary

Fixes #1029.

- Allow the Android time picker config plugin to map `numbersInnerTextColor` to the framework's `android:numbersInnerTextColor` attribute.
- Document the new time picker styling property.
- Add a regression test that runs the plugin through Expo's prebuild mod compiler and verifies the generated `styles.xml`, light `colors.xml`, and dark `colors.xml` output.

## Test Plan

### What's required for testing (prerequisites)?

- Install dependencies with `yarn install --immutable`.

### What are the steps to reproduce (after prerequisites)?

- `yarn test plugin/src/__tests__/withDateTimePickerStyles.test.js --runInBand` — 2 tests passed.
- `yarn test --runInBand` — 24 tests passed across 4 suites.
- `yarn lint` — passed with 0 errors (22 existing warnings).
- `yarn eslint plugin/src/__tests__/withDateTimePickerStyles.test.js` — passed.
- `yarn plugin:build` — passed.
- `yarn prettier --check plugin/src/withDateTimePickerStyles.ts plugin/src/__tests__/withDateTimePickerStyles.test.js docs/android-styling.md` — passed.
- `yarn pack --dry-run` — passed.

Regression evidence:

- Before the whitelist change, the prebuild regression failed in `android.styles` with `Invalid attribute name: numbersInnerTextColor`.
- Temporarily removing the final whitelist entry reproduced the same failure, while the unknown-key test continued to pass.
- A deliberately incorrect light-color assertion failed against the generated `colors.xml` value, confirming the XML assertions are active.
- The final test verifies an unrelated unknown key is still rejected.

`yarn flow` cannot execute on this ARM64 macOS host because the installed macOS Flow binary is x86_64. Running the Linux ARM64 binary in a container also exposes the existing `.flowconfig`/dependency version mismatch (`^0.217.0` vs `0.278.0`) and existing Flow errors. The plugin TypeScript build passes.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ❌      |
| Android |     ✅      |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [x] I have added automated tests, either in JS or e2e tests, as applicable

