### PR TITLE
fix(types): allow design argument in DateTimePickerAndroid.dismiss

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ The `params` is an object with the same properties as the component props docume
 import { DateTimePickerAndroid } from '@react-native-community/datetimepicker';
 
 DateTimePickerAndroid.open(params: AndroidNativeProps)
-DateTimePickerAndroid.dismiss(mode: AndroidNativeProps['mode'])
+DateTimePickerAndroid.dismiss(mode: AndroidNativeProps['mode'], design?: AndroidNativeProps['design'])
 ```
 
 The reason we recommend the imperative API is: on Android, the date/time picker opens in a dialog, similar to `ReactNative.alert()` from core react native. The imperative api models this behavior better than the declarative component api. While the component approach is perfectly functional, based on the issue tracker history, it appears to be more prone to introducing bugs.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -263,7 +263,10 @@ export type WindowsNativeProps = Readonly<
 
 declare namespace DateTimePickerAndroidType {
   const open: (args: AndroidNativeProps) => void;
-  const dismiss: (mode: AndroidNativeProps['mode']) => Promise<boolean>;
+  const dismiss: (
+    mode: AndroidNativeProps['mode'],
+    design?: AndroidNativeProps['design'],
+  ) => Promise<boolean>;
 }
 
 declare const RNDateTimePicker: FC<


### PR DESCRIPTION
# Summary

`DateTimePickerAndroid.dismiss` accepts a second `design` argument at runtime, but the public TypeScript declaration only declares one parameter, so TypeScript users cannot dismiss a Material 3 picker without a cast.

**Runtime** (`src/DateTimePickerAndroid.android.js:143`):

```js
function dismiss(
  mode: AndroidNativeProps['mode'],
  design?: AndroidNativeProps['design'] = 'default',
): Promise<boolean> {
  const pickers = design === 'material' ? materialPickers : defaultPickers;
  return pickers[mode].dismiss();
}
```

**Declaration before this PR** (`src/index.d.ts:266`):

```ts
const dismiss: (mode: AndroidNativeProps['mode']) => Promise<boolean>;
```

The library itself already calls the two-argument form in `src/datetimepicker.android.js:47`:

```js
return () => DateTimePickerAndroid.dismiss(mode, design);
```

The `design` parameter was added to the runtime in #952 (Material 3 pickers) but `index.d.ts` was never updated, so `dismiss` has been under-typed since 9.0.0. Without it, a TypeScript app that opens a Material picker imperatively and then wants to dismiss it either has to omit `design` (which silently falls back to the `default` pickers and dismisses the wrong dialog) or write `(DateTimePickerAndroid.dismiss as any)(mode, 'material')`.

This is a declaration-only change. No runtime behaviour changes.

I also updated the signature shown in the `Android imperative api` section of `README.md` so the documented API matches.

## Test Plan

The repository has no TypeScript type-check step, so I verified the declaration with a local `tsc` run against the repo's own `typescript@5.8.3` and a scratch file (not committed):

```ts
// typecheck-dismiss.ts
import {DateTimePickerAndroid} from './src/index';

DateTimePickerAndroid.dismiss('date', 'material');
DateTimePickerAndroid.dismiss('time');
```

Before the fix, with `master` at `a523007`:

```
$ ./node_modules/.bin/tsc -p tc-tsconfig.json
typecheck-dismiss.ts(4,39): error TS2554: Expected 1 arguments, but got 2.
exit=2
```

After the fix:

```
$ ./node_modules/.bin/tsc -p tc-tsconfig.json
exit=0
```

Counterfactual, reverting only `src/index.d.ts` back to the `HEAD` version and restoring it:

```
### STEP a: WITH FIX
exit=0

### STEP b: REVERT ONLY src/index.d.ts
typecheck-dismiss.ts(4,39): error TS2554: Expected 1 arguments, but got 2.
exit=2

### STEP c: RESTORE
exit=0
```

The new parameter is narrowly typed rather than `any`, so invalid values are still rejected:

```
$ ./node_modules/.bin/tsc -p tc-neg.json   # DateTimePickerAndroid.dismiss('date', 'bogus')
typecheck-neg.ts(2,39): error TS2345: Argument of type '"bogus"' is not assignable to parameter of type 'Design | undefined'.
```

Repository checks:

```
$ yarn lint
22 problems (0 errors, 22 warnings)   # warnings are pre-existing deep-import / jest warnings

$ yarn test
Test Suites: 4 passed, 4 total
Tests:       24 passed, 24 total
Snapshots:   3 passed, 3 total
```

`yarn flow` could not run on this machine (the bundled `flow-bin` binary is x86-only and fails to spawn on arm64). No Flow file is touched by this PR; the Flow annotations on `dismiss` already carry the `design` parameter.

Note on CI: `e2e_ios (old arch)`, `e2e_ios (new arch)` and `e2e_android (old arch)` are already failing on `master` at the base commit `a523007` (run 33481502431), while `analyse_js` passes. Those failures are pre-existing and unrelated to this change.

### What's required for testing (prerequisites)?

`yarn install`, plus the repo's own `typescript` devDependency for the type check above.

### What are the steps to reproduce (after prerequisites)?

In a TypeScript file, call `DateTimePickerAndroid.dismiss('date', 'material')`. On `master` it fails to compile with `TS2554: Expected 1 arguments, but got 2`, even though that is exactly what the library does internally.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ❌      |
| Android |     ✅      |

## Checklist

- [ ] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [ ] I have added automated tests, either in JS or e2e tests, as applicable
