### PR TITLE
chore(android): apply shared prop validation on Android

### DIFF
--- a/src/androidUtils.js
+++ b/src/androidUtils.js
@@ -111,7 +111,13 @@ function getOpenPicker(
 }
 
 function validateAndroidProps(props: AndroidNativeProps) {
-  sharedPropsValidation({value: props?.value});
+  sharedPropsValidation({
+    value: props?.value,
+    timeZoneName: props?.timeZoneName,
+    timeZoneOffsetInMinutes: props?.timeZoneOffsetInMinutes,
+    minimumDate: props?.minimumDate,
+    maximumDate: props?.maximumDate,
+  });
 
   if (props.design !== 'material') validateMaterial3PropsNotUsed(props);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,7 +6,6 @@ import RNDateTimePickerWindows, {
 import RNDateTimePickerAndroid from '../src/datetimepicker.android';
 import {DateTimePickerAndroid} from '../src/DateTimePickerAndroid.android';
 import NativeDateTimePickerIOS from '../src/picker.ios';
-import {DateTimePickerAndroid} from '../src/DateTimePickerAndroid';
 import {render, fireEvent, waitFor} from '@testing-library/react-native';
 import {EVENT_TYPE_SET} from '../src/constants';
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,6 +4,7 @@ import RNDateTimePickerWindows, {
   RNDateTimePickerWindows as NativeDateTimePickerWindows,
 } from '../src/datetimepicker.windows';
 import RNDateTimePickerAndroid from '../src/datetimepicker.android';
+import {DateTimePickerAndroid} from '../src/DateTimePickerAndroid.android';
 import NativeDateTimePickerIOS from '../src/picker.ios';
 import {render, fireEvent, waitFor} from '@testing-library/react-native';
 import {EVENT_TYPE_SET} from '../src/constants';
@@ -54,6 +55,31 @@ describe('DateTimePicker', () => {
     ])('throws when invalid props %s are passed', (props, expected) => {
       expect(() => RNDateTimePickerAndroid(props)).toThrow(expected);
     });
+
+    it.each([
+      [
+        {
+          value: new Date('2023-06-15'),
+          minimumDate: new Date('2023-12-31'),
+          maximumDate: new Date('2023-01-01'),
+        },
+        'DateTimePicker: minimumDate (2023-12-31T00:00:00.000Z) is after maximumDate (2023-01-01T00:00:00.000Z). Ensure minimumDate < maximumDate.',
+      ],
+      [
+        {
+          value: new Date(DATE),
+          timeZoneName: 'Europe/Prague',
+          timeZoneOffsetInMinutes: 60,
+        },
+        '`timeZoneName` and `timeZoneOffsetInMinutes` cannot be specified at the same time',
+      ],
+    ])(
+      'runs the shared prop validation on %s, in both the component and the imperative api',
+      (props, expected) => {
+        expect(() => DateTimePickerAndroid.open(props)).toThrow(expected);
+        expect(() => RNDateTimePickerAndroid(props)).toThrow(expected);
+      },
+    );
   });
 
   describe('RNDateTimePickerIOS', () => {


### PR DESCRIPTION
# Summary

`sharedPropsValidation` (`src/utils.js:34`) performs four checks: `value` is a `Date`, `minimumDate <= maximumDate`, `timeZoneName` and `timeZoneOffsetInMinutes` are not both set, and a deprecation warning for `timeZoneOffsetInMinutes`.

iOS runs all of them (`src/datetimepicker.ios.js:70-76`):

```js
sharedPropsValidation({
  value,
  timeZoneOffsetInMinutes,
  timeZoneName,
  minimumDate,
  maximumDate,
});
```

Android runs only the first (`src/androidUtils.js:114`, before this PR):

```js
function validateAndroidProps(props: AndroidNativeProps) {
  sharedPropsValidation({value: props?.value});
```

All four props are supported on Android and documented as such in `README.md`: `minimumDate` / `maximumDate` ("on Android, this only works for `date` mode"), `timeZoneName` and `timeZoneOffsetInMinutes` (both marked `iOS and Android only`, the latter deprecated). So the checks are simply not reaching the Android path.

`validateAndroidProps` is the single validation entry point for both public Android APIs, so both are affected: the component (`src/datetimepicker.android.js:15`) and the imperative api (`src/DateTimePickerAndroid.android.js:57`).

## What happens today on Android with `minimumDate > maximumDate`

Instead of the error iOS raises, the contradictory bounds reach the native dialog:

- Default picker, `android/src/main/java/com/reactcommunity/rndatetimepicker/RNDatePickerDialogFragment.java:142`

  ```java
  long timestamp = Math.min(Math.max(calendar.getTimeInMillis(), minDate), maxDate);
  ```

  With `minDate > maxDate` this clamp collapses to `maxDate` for every date the user picks, and the dialog silently snaps back on each selection.

- Material picker, `android/src/main/java/com/reactcommunity/rndatetimepicker/RNMaterialDatePicker.kt:92-102`

  `CompositeDateValidator.allOf([DateValidatorPointForward.from(minDate), DateValidatorPointBackward.before(maxDate)])` matches no date at all, so the whole calendar is disabled.

The example app already has a button for this (`example/App.js:486-506`), commented "This button allows for testing the error box that should show when the minimumDate prop is greater than the maximumDate prop" and labelled `set min > max (errors)`. On iOS it errors as the label says; on Android it does not.

The same applies to `timeZoneName` + `timeZoneOffsetInMinutes`: on Android both are forwarded to the native module and `Common.getTimeZone` (`android/src/main/java/com/reactcommunity/rndatetimepicker/Common.java:182`) silently prefers one of them rather than reporting the conflict.

## The change

`validateAndroidProps` now forwards the remaining shared props. One file, five lines. No new validation logic is introduced; the existing shared checks simply reach Android.

This PR is Android-scoped. `datetimepicker.windows.js` passes only `value` as well, but the Windows props differ (`timeZoneOffsetInSeconds` rather than `timeZoneOffsetInMinutes`), so I left it alone rather than guess.

## Test Plan

Added two cases to the existing `AndroidDateTimePicker` block in `test/index.test.js`, each asserting both entry points (`DateTimePickerAndroid.open` and the component).

Counterfactual, restoring only `src/androidUtils.js` to its pre-fix state and running with `--no-cache`:

```
$ git show HEAD:src/androidUtils.js > src/androidUtils.js
$ yarn jest --no-cache -t "runs the shared prop validation"

  ● DateTimePicker › AndroidDateTimePicker › runs the shared prop validation on {
    value: 2023-06-15T00:00:00.000Z,
    minimumDate: 2023-12-31T00:00:00.000Z,
    maximumDate: 2023-01-01T00:00:00.000Z
  }, in both the component and the imperative api

    expect(received).toThrow(expected)

    Expected substring: "DateTimePicker: minimumDate (2023-12-31T00:00:00.000Z) is after maximumDate (2023-01-01T00:00:00.000Z). Ensure minimumDate < maximumDate."

    Received function did not throw

  ● DateTimePicker › AndroidDateTimePicker › runs the shared prop validation on {
    value: 2013-08-19T22:00:00.000Z,
    timeZoneName: 'Europe/Prague',
    timeZoneOffsetInMinutes: 60
  }, in both the component and the imperative api

    expect(received).toThrow(expected)

    Expected substring: "`timeZoneName` and `timeZoneOffsetInMinutes` cannot be specified at the same time"

    Received function did not throw

Tests:       2 failed, 24 skipped, 26 total
```

With the fix restored:

```
$ yarn jest --no-cache
Test Suites: 4 passed, 4 total
Tests:       26 passed, 26 total
Snapshots:   3 passed, 3 total
```

The two cases are independently sensitive. Dropping only `minimumDate` from the forwarded props fails the first case and leaves the second green; dropping only `timeZoneName` does the reverse:

```
# minimumDate: undefined
Expected substring: "DateTimePicker: minimumDate (...) is after maximumDate (...). Ensure minimumDate < maximumDate."
Received function did not throw
Tests:       1 failed, 24 skipped, 1 passed, 26 total

# timeZoneName: undefined
Expected substring: "`timeZoneName` and `timeZoneOffsetInMinutes` cannot be specified at the same time"
Received function did not throw
Tests:       1 failed, 24 skipped, 1 passed, 26 total
```

`yarn lint` reports 0 errors and 22 warnings, unchanged from `master` (pre-existing deep-import and `jest/expect-expect` warnings). `yarn flow` could not run on this machine; the bundled `flow-bin` binary is x86-only and fails to spawn on arm64. The change adds no new type surface.

### What's required for testing (prerequisites)?

`yarn`

### What are the steps to reproduce (after prerequisites)?

`yarn test`

On a device: in the example app, press `set min > max (errors)`. iOS raises the invariant; Android opens a dialog whose selection is clamped (default design) or fully disabled (material design).

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ❌      |
| Android |     ✅      |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [x] I have added automated tests, either in JS or e2e tests, as applicable
