### PR TITLE
fix(windows): respect the timeZoneOffsetInSeconds prop

### DIFF
--- a/src/datetimepicker.windows.js
+++ b/src/datetimepicker.windows.js
@@ -70,12 +70,11 @@ export default function RNDateTimePickerQWE(
     }
   };
 
-  // $FlowFixMe[recursive-definition]
   const timezoneOffsetInSeconds = (() => {
     // The Date object returns timezone in minutes. Convert that to seconds
     // and multiply by -1 so that the offset can be added to UTC+0 time to get
     // the correct value on the native side.
-    if (timezoneOffsetInSeconds == null && props.value != null) {
+    if (props.timeZoneOffsetInSeconds == null && props.value != null) {
       return -60 * props.value.getTimezoneOffset();
     }
     return props.timeZoneOffsetInSeconds;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -67,6 +67,31 @@ describe('DateTimePicker', () => {
     });
   });
 
+  describe('RNDateTimePickerWindows', () => {
+    it.each([0, 3600, -18000])(
+      'passes timeZoneOffsetInSeconds %s to native Component',
+      async (timeZoneOffsetInSeconds) => {
+        const {toJSON} = await renderPicker(RNDateTimePickerWindows, {
+          timeZoneOffsetInSeconds,
+        });
+
+        expect(toJSON()).toHaveProperty(
+          'props.timeZoneOffsetInSeconds',
+          timeZoneOffsetInSeconds,
+        );
+      },
+    );
+
+    it('falls back to the device offset when timeZoneOffsetInSeconds is omitted', async () => {
+      const {toJSON} = await renderPicker(RNDateTimePickerWindows);
+
+      expect(toJSON()).toHaveProperty(
+        'props.timeZoneOffsetInSeconds',
+        -60 * new Date(DATE).getTimezoneOffset(),
+      );
+    });
+  });
+
   test.each([
     [RNDateTimePickerIOS, NativeDateTimePickerIOS, 'timestamp'],
     [RNDateTimePickerWindows, NativeDateTimePickerWindows, 'newDate'],


### PR DESCRIPTION
# Summary

The `timeZoneOffsetInSeconds` prop (documented as Windows only) is ignored. Whatever the caller passes, the picker always receives the device's own time zone offset derived from `value`.

The IIFE that computes the offset checks `timezoneOffsetInSeconds == null`, which is the `const` it is currently initializing, rather than `props.timeZoneOffsetInSeconds`. The self-reference is what the `// $FlowFixMe[recursive-definition]` above it was suppressing. Because that identifier is never anything but `undefined` at that point, the device-offset branch always wins and `return props.timeZoneOffsetInSeconds` is dead code.

Reproduction, on a machine in UTC+7:

```jsx
<RNDateTimePicker value={new Date()} timeZoneOffsetInSeconds={3600} />
```

`RNDateTimePickerWindows` receives `timeZoneOffsetInSeconds={25200}` instead of `3600`.

Fix is one identifier: test the prop instead of the variable being defined. The `$FlowFixMe[recursive-definition]` suppression is removed with it, since there is no longer a recursive definition.

`timeZoneOffsetInMinutes` on the iOS entry point does not have this problem; it is forwarded straight to the native component in `datetimepicker.ios.js`.

## Test Plan

`test/index.test.js` gains a `RNDateTimePickerWindows` block asserting that the value passed as `timeZoneOffsetInSeconds` is the value the native component receives, plus one case pinning the existing device-offset fallback when the prop is omitted.

Three offsets are used (`0`, `3600`, `-18000`) so the test cannot pass by coincidence in a single machine time zone: without the fix the received value is the same device offset in all three cases.

### What's required for testing (prerequisites)?

`yarn install`.

### What are the steps to reproduce (after prerequisites)?

`yarn test`. Before the fix:

```
  ● DateTimePicker › RNDateTimePickerWindows › passes timeZoneOffsetInSeconds 3600 to native Component

    expect(received).toHaveProperty(path, value)

    Expected path: "props.timeZoneOffsetInSeconds"

    Expected value: 3600
    Received value: 25200
```

After the fix the whole suite is green: 28 passed, up from 24.

I could not run `yarn flow` locally, `flow-bin` only ships an x86_64 macOS binary and this machine has no Rosetta. The change removes a suppression rather than adding one, so it should not introduce an unused-suppression error.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |     ❌      |
| Android |     ❌      |
| Windows |     ✅      |

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
- [x] I have added automated tests, either in JS or e2e tests, as applicable

The prop is already documented in `README.md` and already typed in both `src/types.js` and `src/index.d.ts`; this only makes the implementation match. I do not have a Windows machine, so the verification is the JS unit test rather than a device run.
