### PR TITLE
chore(ci): make the Test workflow green

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Install applesimutils
         run: |
           HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
+          HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_AUTO_UPDATE=1 brew trust wix/brew >/dev/null
           HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null
       - run: corepack enable
       - uses: actions/setup-node@v6

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,6 +5,8 @@ import RNDateTimePickerWindows, {
 } from '../src/datetimepicker.windows';
 import RNDateTimePickerAndroid from '../src/datetimepicker.android';
 import {DateTimePickerAndroid} from '../src/DateTimePickerAndroid.android';
+// jest resolves platform files as ios, so the component uses this fallback module
+import {DateTimePickerAndroid as ResolvedDateTimePickerAndroid} from '../src/DateTimePickerAndroid';
 import NativeDateTimePickerIOS from '../src/picker.ios';
 import {render, fireEvent, waitFor} from '@testing-library/react-native';
 import {EVENT_TYPE_SET} from '../src/constants';
@@ -80,13 +82,13 @@ describe('DateTimePicker', () => {
         expect(() => RNDateTimePickerAndroid(props)).toThrow(expected);
       },
     );
-    
+
     it('reopens the picker when the design changes', () => {
       const open = jest
-        .spyOn(DateTimePickerAndroid, 'open')
+        .spyOn(ResolvedDateTimePickerAndroid, 'open')
         .mockImplementation(() => {});
       jest
-        .spyOn(DateTimePickerAndroid, 'dismiss')
+        .spyOn(ResolvedDateTimePickerAndroid, 'dismiss')
         .mockImplementation(() => Promise.resolve(true));
 
       const {rerender} = render(


### PR DESCRIPTION
## Summary

Fixes two failures in the `Test` workflow on master:

- **Jest** ([run](https://github.com/react-native-datetimepicker/datetimepicker/actions/runs/34143040055/job/101809142023)): the test added in #1055 spied on `DateTimePickerAndroid.android`. Jest resolves platform files as iOS, so `datetimepicker.android.js` imports the `DateTimePickerAndroid.js` fallback instead. The spy never recorded a call. The test now spies on the module the component resolves.
- **Install applesimutils** ([run](https://github.com/react-native-datetimepicker/datetimepicker/actions/runs/33481502431/job/99771929893)): Homebrew now refuses formulas from untrusted third-party taps (`Refusing to load formula wix/brew/applesimutils from untrusted tap wix/brew`). The step now runs `brew trust wix/brew` before the install.

## Test plan

- [x] `yarn jest` passes locally (31 tests)
- [ ] `analyse_js` and `e2e_ios` jobs pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)